### PR TITLE
Support "event" sensor and sending "events" to the host

### DIFF
--- a/examples/glfw.py
+++ b/examples/glfw.py
@@ -33,386 +33,410 @@
 # Upgrade to 3.1.x api.
 # -----------------------------------------------------------------------------
 
-import sys,os
+import sys, os
 import ctypes
-from ctypes import c_int,c_ushort,c_char_p,c_double,c_uint, c_char,c_float,Structure,CFUNCTYPE,byref,POINTER
+from ctypes import (
+    c_int,
+    c_ushort,
+    c_char_p,
+    c_double,
+    c_uint,
+    c_char,
+    c_float,
+    Structure,
+    CFUNCTYPE,
+    byref,
+    POINTER,
+)
 import platform
 from ctypes.util import find_library
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 os_name = platform.system()
 del platform
 
 
-if getattr(sys, 'frozen', False):
+if getattr(sys, "frozen", False):
     # we are running in a |PyInstaller| bundle using a local version
     # you will need to add glfw.so/dylib in your spec file.
     if os_name == "Linux":
-        filename = 'libglfw.so'
+        filename = "libglfw.so"
     elif os_name == "Darwin":
-        filename = 'libglfw3.dylib'
+        filename = "libglfw3.dylib"
     elif os_name == "Windows":
-        filename = 'glfw3.dll'
+        filename = "glfw3.dll"
     else:
-        filename = 'libglfw.dll'
-    dll_path = os.path.join(sys._MEIPASS,filename)
+        filename = "libglfw.dll"
+    dll_path = os.path.join(sys._MEIPASS, filename)
 
 else:
     # we are running in a normal Python environment
     if os_name == "Windows":
-        dll_path = find_library('glfw3')
+        dll_path = find_library("glfw3")
     else:
-        dll_path = find_library('glfw')
+        dll_path = find_library("glfw")
     if not dll_path:
-        raise RuntimeError('GLFW library not found')
+        raise RuntimeError("GLFW library not found")
 
 _glfw = ctypes.CDLL(dll_path)
 
 # --- Version -----------------------------------------------------------------
-GLFW_VERSION_MAJOR      = 3
-GLFW_VERSION_MINOR      = 1
-GLFW_VERSION_REVISION   = 1
+GLFW_VERSION_MAJOR = 3
+GLFW_VERSION_MINOR = 1
+GLFW_VERSION_REVISION = 1
 __version__ = GLFW_VERSION_MAJOR, GLFW_VERSION_MINOR, GLFW_VERSION_REVISION
 
 # --- Input handling definitions ----------------------------------------------
-GLFW_RELEASE            = 0
-GLFW_PRESS              = 1
-GLFW_REPEAT             = 2
+GLFW_RELEASE = 0
+GLFW_PRESS = 1
+GLFW_REPEAT = 2
 
 # --- Keys --------------------------------------------------------------------
 
 # --- The unknown key ---------------------------------------------------------
-GLFW_KEY_UNKNOWN          = -1
+GLFW_KEY_UNKNOWN = -1
 
 # --- Printable keys ----------------------------------------------------------
-GLFW_KEY_SPACE            = 32
-GLFW_KEY_APOSTROPHE       = 39 # ''
-GLFW_KEY_COMMA            = 44 # ,
-GLFW_KEY_MINUS            = 45 # -
-GLFW_KEY_PERIOD           = 46 # .
-GLFW_KEY_SLASH            = 47 # /
-GLFW_KEY_0                = 48
-GLFW_KEY_1                = 49
-GLFW_KEY_2                = 50
-GLFW_KEY_3                = 51
-GLFW_KEY_4                = 52
-GLFW_KEY_5                = 53
-GLFW_KEY_6                = 54
-GLFW_KEY_7                = 55
-GLFW_KEY_8                = 56
-GLFW_KEY_9                = 57
-GLFW_KEY_SEMICOLON        = 59 # ;
-GLFW_KEY_EQUAL            = 61 # =
-GLFW_KEY_A                = 65
-GLFW_KEY_B                = 66
-GLFW_KEY_C                = 67
-GLFW_KEY_D                = 68
-GLFW_KEY_E                = 69
-GLFW_KEY_F                = 70
-GLFW_KEY_G                = 71
-GLFW_KEY_H                = 72
-GLFW_KEY_I                = 73
-GLFW_KEY_J                = 74
-GLFW_KEY_K                = 75
-GLFW_KEY_L                = 76
-GLFW_KEY_M                = 77
-GLFW_KEY_N                = 78
-GLFW_KEY_O                = 79
-GLFW_KEY_P                = 80
-GLFW_KEY_Q                = 81
-GLFW_KEY_R                = 82
-GLFW_KEY_S                = 83
-GLFW_KEY_T                = 84
-GLFW_KEY_U                = 85
-GLFW_KEY_V                = 86
-GLFW_KEY_W                = 87
-GLFW_KEY_X                = 88
-GLFW_KEY_Y                = 89
-GLFW_KEY_Z                = 90
-GLFW_KEY_LEFT_BRACKET     = 91  # [
-GLFW_KEY_BACKSLASH        = 92  # \
-GLFW_KEY_RIGHT_BRACKET    = 93  # ]
-GLFW_KEY_GRAVE_ACCENT     = 96  # `
-GLFW_KEY_WORLD_1          = 161 # non-US #1
-GLFW_KEY_WORLD_2          = 162 # non-US #2
+GLFW_KEY_SPACE = 32
+GLFW_KEY_APOSTROPHE = 39  # ''
+GLFW_KEY_COMMA = 44  # ,
+GLFW_KEY_MINUS = 45  # -
+GLFW_KEY_PERIOD = 46  # .
+GLFW_KEY_SLASH = 47  # /
+GLFW_KEY_0 = 48
+GLFW_KEY_1 = 49
+GLFW_KEY_2 = 50
+GLFW_KEY_3 = 51
+GLFW_KEY_4 = 52
+GLFW_KEY_5 = 53
+GLFW_KEY_6 = 54
+GLFW_KEY_7 = 55
+GLFW_KEY_8 = 56
+GLFW_KEY_9 = 57
+GLFW_KEY_SEMICOLON = 59  # ;
+GLFW_KEY_EQUAL = 61  # =
+GLFW_KEY_A = 65
+GLFW_KEY_B = 66
+GLFW_KEY_C = 67
+GLFW_KEY_D = 68
+GLFW_KEY_E = 69
+GLFW_KEY_F = 70
+GLFW_KEY_G = 71
+GLFW_KEY_H = 72
+GLFW_KEY_I = 73
+GLFW_KEY_J = 74
+GLFW_KEY_K = 75
+GLFW_KEY_L = 76
+GLFW_KEY_M = 77
+GLFW_KEY_N = 78
+GLFW_KEY_O = 79
+GLFW_KEY_P = 80
+GLFW_KEY_Q = 81
+GLFW_KEY_R = 82
+GLFW_KEY_S = 83
+GLFW_KEY_T = 84
+GLFW_KEY_U = 85
+GLFW_KEY_V = 86
+GLFW_KEY_W = 87
+GLFW_KEY_X = 88
+GLFW_KEY_Y = 89
+GLFW_KEY_Z = 90
+GLFW_KEY_LEFT_BRACKET = 91  # [
+GLFW_KEY_BACKSLASH = 92  # \
+GLFW_KEY_RIGHT_BRACKET = 93  # ]
+GLFW_KEY_GRAVE_ACCENT = 96  # `
+GLFW_KEY_WORLD_1 = 161  # non-US #1
+GLFW_KEY_WORLD_2 = 162  # non-US #2
 
 # --- Function keys -----------------------------------------------------------
-GLFW_KEY_ESCAPE           = 256
-GLFW_KEY_ENTER            = 257
-GLFW_KEY_TAB              = 258
-GLFW_KEY_BACKSPACE        = 259
-GLFW_KEY_INSERT           = 260
-GLFW_KEY_DELETE           = 261
-GLFW_KEY_RIGHT            = 262
-GLFW_KEY_LEFT             = 263
-GLFW_KEY_DOWN             = 264
-GLFW_KEY_UP               = 265
-GLFW_KEY_PAGE_UP          = 266
-GLFW_KEY_PAGE_DOWN        = 267
-GLFW_KEY_HOME             = 268
-GLFW_KEY_END              = 269
-GLFW_KEY_CAPS_LOCK        = 280
-GLFW_KEY_SCROLL_LOCK      = 281
-GLFW_KEY_NUM_LOCK         = 282
-GLFW_KEY_PRINT_SCREEN     = 283
-GLFW_KEY_PAUSE            = 284
-GLFW_KEY_F1               = 290
-GLFW_KEY_F2               = 291
-GLFW_KEY_F3               = 292
-GLFW_KEY_F4               = 293
-GLFW_KEY_F5               = 294
-GLFW_KEY_F6               = 295
-GLFW_KEY_F7               = 296
-GLFW_KEY_F8               = 297
-GLFW_KEY_F9               = 298
-GLFW_KEY_F10              = 299
-GLFW_KEY_F11              = 300
-GLFW_KEY_F12              = 301
-GLFW_KEY_F13              = 302
-GLFW_KEY_F14              = 303
-GLFW_KEY_F15              = 304
-GLFW_KEY_F16              = 305
-GLFW_KEY_F17              = 306
-GLFW_KEY_F18              = 307
-GLFW_KEY_F19              = 308
-GLFW_KEY_F20              = 309
-GLFW_KEY_F21              = 310
-GLFW_KEY_F22              = 311
-GLFW_KEY_F23              = 312
-GLFW_KEY_F24              = 313
-GLFW_KEY_F25              = 314
-GLFW_KEY_KP_0             = 320
-GLFW_KEY_KP_1             = 321
-GLFW_KEY_KP_2             = 322
-GLFW_KEY_KP_3             = 323
-GLFW_KEY_KP_4             = 324
-GLFW_KEY_KP_5             = 325
-GLFW_KEY_KP_6             = 326
-GLFW_KEY_KP_7             = 327
-GLFW_KEY_KP_8             = 328
-GLFW_KEY_KP_9             = 329
-GLFW_KEY_KP_DECIMAL       = 330
-GLFW_KEY_KP_DIVIDE        = 331
-GLFW_KEY_KP_MULTIPLY      = 332
-GLFW_KEY_KP_SUBTRACT      = 333
-GLFW_KEY_KP_ADD           = 334
-GLFW_KEY_KP_ENTER         = 335
-GLFW_KEY_KP_EQUAL         = 336
-GLFW_KEY_LEFT_SHIFT       = 340
-GLFW_KEY_LEFT_CONTROL     = 341
-GLFW_KEY_LEFT_ALT         = 342
-GLFW_KEY_LEFT_SUPER       = 343
-GLFW_KEY_RIGHT_SHIFT      = 344
-GLFW_KEY_RIGHT_CONTROL    = 345
-GLFW_KEY_RIGHT_ALT        = 346
-GLFW_KEY_RIGHT_SUPER      = 347
-GLFW_KEY_MENU             = 348
-GLFW_KEY_LAST             = GLFW_KEY_MENU
+GLFW_KEY_ESCAPE = 256
+GLFW_KEY_ENTER = 257
+GLFW_KEY_TAB = 258
+GLFW_KEY_BACKSPACE = 259
+GLFW_KEY_INSERT = 260
+GLFW_KEY_DELETE = 261
+GLFW_KEY_RIGHT = 262
+GLFW_KEY_LEFT = 263
+GLFW_KEY_DOWN = 264
+GLFW_KEY_UP = 265
+GLFW_KEY_PAGE_UP = 266
+GLFW_KEY_PAGE_DOWN = 267
+GLFW_KEY_HOME = 268
+GLFW_KEY_END = 269
+GLFW_KEY_CAPS_LOCK = 280
+GLFW_KEY_SCROLL_LOCK = 281
+GLFW_KEY_NUM_LOCK = 282
+GLFW_KEY_PRINT_SCREEN = 283
+GLFW_KEY_PAUSE = 284
+GLFW_KEY_F1 = 290
+GLFW_KEY_F2 = 291
+GLFW_KEY_F3 = 292
+GLFW_KEY_F4 = 293
+GLFW_KEY_F5 = 294
+GLFW_KEY_F6 = 295
+GLFW_KEY_F7 = 296
+GLFW_KEY_F8 = 297
+GLFW_KEY_F9 = 298
+GLFW_KEY_F10 = 299
+GLFW_KEY_F11 = 300
+GLFW_KEY_F12 = 301
+GLFW_KEY_F13 = 302
+GLFW_KEY_F14 = 303
+GLFW_KEY_F15 = 304
+GLFW_KEY_F16 = 305
+GLFW_KEY_F17 = 306
+GLFW_KEY_F18 = 307
+GLFW_KEY_F19 = 308
+GLFW_KEY_F20 = 309
+GLFW_KEY_F21 = 310
+GLFW_KEY_F22 = 311
+GLFW_KEY_F23 = 312
+GLFW_KEY_F24 = 313
+GLFW_KEY_F25 = 314
+GLFW_KEY_KP_0 = 320
+GLFW_KEY_KP_1 = 321
+GLFW_KEY_KP_2 = 322
+GLFW_KEY_KP_3 = 323
+GLFW_KEY_KP_4 = 324
+GLFW_KEY_KP_5 = 325
+GLFW_KEY_KP_6 = 326
+GLFW_KEY_KP_7 = 327
+GLFW_KEY_KP_8 = 328
+GLFW_KEY_KP_9 = 329
+GLFW_KEY_KP_DECIMAL = 330
+GLFW_KEY_KP_DIVIDE = 331
+GLFW_KEY_KP_MULTIPLY = 332
+GLFW_KEY_KP_SUBTRACT = 333
+GLFW_KEY_KP_ADD = 334
+GLFW_KEY_KP_ENTER = 335
+GLFW_KEY_KP_EQUAL = 336
+GLFW_KEY_LEFT_SHIFT = 340
+GLFW_KEY_LEFT_CONTROL = 341
+GLFW_KEY_LEFT_ALT = 342
+GLFW_KEY_LEFT_SUPER = 343
+GLFW_KEY_RIGHT_SHIFT = 344
+GLFW_KEY_RIGHT_CONTROL = 345
+GLFW_KEY_RIGHT_ALT = 346
+GLFW_KEY_RIGHT_SUPER = 347
+GLFW_KEY_MENU = 348
+GLFW_KEY_LAST = GLFW_KEY_MENU
 
 
 # --- Modifiers ---------------------------------------------------------------
-GLFW_MOD_SHIFT            = 0x0001
-GLFW_MOD_CONTROL          = 0x0002
-GLFW_MOD_ALT              = 0x0004
-GLFW_MOD_SUPER            = 0x0008
+GLFW_MOD_SHIFT = 0x0001
+GLFW_MOD_CONTROL = 0x0002
+GLFW_MOD_ALT = 0x0004
+GLFW_MOD_SUPER = 0x0008
 
 # --- Mouse -------------------------------------------------------------------
-GLFW_MOUSE_BUTTON_1       = 0
-GLFW_MOUSE_BUTTON_2       = 1
-GLFW_MOUSE_BUTTON_3       = 2
-GLFW_MOUSE_BUTTON_4       = 3
-GLFW_MOUSE_BUTTON_5       = 4
-GLFW_MOUSE_BUTTON_6       = 5
-GLFW_MOUSE_BUTTON_7       = 6
-GLFW_MOUSE_BUTTON_8       = 7
-GLFW_MOUSE_BUTTON_LAST    = GLFW_MOUSE_BUTTON_8
-GLFW_MOUSE_BUTTON_LEFT    = GLFW_MOUSE_BUTTON_1
-GLFW_MOUSE_BUTTON_RIGHT   = GLFW_MOUSE_BUTTON_2
-GLFW_MOUSE_BUTTON_MIDDLE  = GLFW_MOUSE_BUTTON_3
+GLFW_MOUSE_BUTTON_1 = 0
+GLFW_MOUSE_BUTTON_2 = 1
+GLFW_MOUSE_BUTTON_3 = 2
+GLFW_MOUSE_BUTTON_4 = 3
+GLFW_MOUSE_BUTTON_5 = 4
+GLFW_MOUSE_BUTTON_6 = 5
+GLFW_MOUSE_BUTTON_7 = 6
+GLFW_MOUSE_BUTTON_8 = 7
+GLFW_MOUSE_BUTTON_LAST = GLFW_MOUSE_BUTTON_8
+GLFW_MOUSE_BUTTON_LEFT = GLFW_MOUSE_BUTTON_1
+GLFW_MOUSE_BUTTON_RIGHT = GLFW_MOUSE_BUTTON_2
+GLFW_MOUSE_BUTTON_MIDDLE = GLFW_MOUSE_BUTTON_3
 
 
 # --- Joystick ----------------------------------------------------------------
-GLFW_JOYSTICK_1           = 0
-GLFW_JOYSTICK_2           = 1
-GLFW_JOYSTICK_3           = 2
-GLFW_JOYSTICK_4           = 3
-GLFW_JOYSTICK_5           = 4
-GLFW_JOYSTICK_6           = 5
-GLFW_JOYSTICK_7           = 6
-GLFW_JOYSTICK_8           = 7
-GLFW_JOYSTICK_9           = 8
-GLFW_JOYSTICK_10          = 9
-GLFW_JOYSTICK_11          = 10
-GLFW_JOYSTICK_12          = 11
-GLFW_JOYSTICK_13          = 12
-GLFW_JOYSTICK_14          = 13
-GLFW_JOYSTICK_15          = 14
-GLFW_JOYSTICK_16          = 15
-GLFW_JOYSTICK_LAST        = GLFW_JOYSTICK_16
+GLFW_JOYSTICK_1 = 0
+GLFW_JOYSTICK_2 = 1
+GLFW_JOYSTICK_3 = 2
+GLFW_JOYSTICK_4 = 3
+GLFW_JOYSTICK_5 = 4
+GLFW_JOYSTICK_6 = 5
+GLFW_JOYSTICK_7 = 6
+GLFW_JOYSTICK_8 = 7
+GLFW_JOYSTICK_9 = 8
+GLFW_JOYSTICK_10 = 9
+GLFW_JOYSTICK_11 = 10
+GLFW_JOYSTICK_12 = 11
+GLFW_JOYSTICK_13 = 12
+GLFW_JOYSTICK_14 = 13
+GLFW_JOYSTICK_15 = 14
+GLFW_JOYSTICK_16 = 15
+GLFW_JOYSTICK_LAST = GLFW_JOYSTICK_16
 
 
 # --- Error codes -------------------------------------------------------------
-GLFW_NOT_INITIALIZED        = 0x00010001
-GLFW_NO_CURRENT_CONTEXT     = 0x00010002
-GLFW_INVALID_ENUM           = 0x00010003
-GLFW_INVALID_VALUE          = 0x00010004
-GLFW_OUT_OF_MEMORY          = 0x00010005
-GLFW_API_UNAVAILABLE        = 0x00010006
-GLFW_VERSION_UNAVAILABLE    = 0x00010007
-GLFW_PLATFORM_ERROR         = 0x00010008
-GLFW_FORMAT_UNAVAILABLE     = 0x00010009
+GLFW_NOT_INITIALIZED = 0x00010001
+GLFW_NO_CURRENT_CONTEXT = 0x00010002
+GLFW_INVALID_ENUM = 0x00010003
+GLFW_INVALID_VALUE = 0x00010004
+GLFW_OUT_OF_MEMORY = 0x00010005
+GLFW_API_UNAVAILABLE = 0x00010006
+GLFW_VERSION_UNAVAILABLE = 0x00010007
+GLFW_PLATFORM_ERROR = 0x00010008
+GLFW_FORMAT_UNAVAILABLE = 0x00010009
 
 # ---
-GLFW_FOCUSED                = 0x00020001
-GLFW_ICONIFIED              = 0x00020002
-GLFW_RESIZABLE              = 0x00020003
-GLFW_VISIBLE                = 0x00020004
-GLFW_DECORATED              = 0x00020005
+GLFW_FOCUSED = 0x00020001
+GLFW_ICONIFIED = 0x00020002
+GLFW_RESIZABLE = 0x00020003
+GLFW_VISIBLE = 0x00020004
+GLFW_DECORATED = 0x00020005
 
 # ---
-GLFW_RED_BITS               = 0x00021001
-GLFW_GREEN_BITS             = 0x00021002
-GLFW_BLUE_BITS              = 0x00021003
-GLFW_ALPHA_BITS             = 0x00021004
-GLFW_DEPTH_BITS             = 0x00021005
-GLFW_STENCIL_BITS           = 0x00021006
-GLFW_ACCUM_RED_BITS         = 0x00021007
-GLFW_ACCUM_GREEN_BITS       = 0x00021008
-GLFW_ACCUM_BLUE_BITS        = 0x00021009
-GLFW_ACCUM_ALPHA_BITS       = 0x0002100A
-GLFW_AUX_BUFFERS            = 0x0002100B
-GLFW_STEREO                 = 0x0002100C
-GLFW_SAMPLES                = 0x0002100D
-GLFW_SRGB_CAPABLE           = 0x0002100E
-GLFW_REFRESH_RATE           = 0x0002100F
+GLFW_RED_BITS = 0x00021001
+GLFW_GREEN_BITS = 0x00021002
+GLFW_BLUE_BITS = 0x00021003
+GLFW_ALPHA_BITS = 0x00021004
+GLFW_DEPTH_BITS = 0x00021005
+GLFW_STENCIL_BITS = 0x00021006
+GLFW_ACCUM_RED_BITS = 0x00021007
+GLFW_ACCUM_GREEN_BITS = 0x00021008
+GLFW_ACCUM_BLUE_BITS = 0x00021009
+GLFW_ACCUM_ALPHA_BITS = 0x0002100A
+GLFW_AUX_BUFFERS = 0x0002100B
+GLFW_STEREO = 0x0002100C
+GLFW_SAMPLES = 0x0002100D
+GLFW_SRGB_CAPABLE = 0x0002100E
+GLFW_REFRESH_RATE = 0x0002100F
 
 # ---
-GLFW_CLIENT_API             = 0x00022001
-GLFW_CONTEXT_VERSION_MAJOR  = 0x00022002
-GLFW_CONTEXT_VERSION_MINOR  = 0x00022003
-GLFW_CONTEXT_REVISION       = 0x00022004
-GLFW_CONTEXT_ROBUSTNESS     = 0x00022005
-GLFW_OPENGL_FORWARD_COMPAT  = 0x00022006
-GLFW_OPENGL_DEBUG_CONTEXT   = 0x00022007
-GLFW_OPENGL_PROFILE         = 0x00022008
+GLFW_CLIENT_API = 0x00022001
+GLFW_CONTEXT_VERSION_MAJOR = 0x00022002
+GLFW_CONTEXT_VERSION_MINOR = 0x00022003
+GLFW_CONTEXT_REVISION = 0x00022004
+GLFW_CONTEXT_ROBUSTNESS = 0x00022005
+GLFW_OPENGL_FORWARD_COMPAT = 0x00022006
+GLFW_OPENGL_DEBUG_CONTEXT = 0x00022007
+GLFW_OPENGL_PROFILE = 0x00022008
 
 # ---
-GLFW_OPENGL_API             = 0x00030001
-GLFW_OPENGL_ES_API          = 0x00030002
+GLFW_OPENGL_API = 0x00030001
+GLFW_OPENGL_ES_API = 0x00030002
 
 # ---
-GLFW_NO_ROBUSTNESS          =          0
-GLFW_NO_RESET_NOTIFICATION  = 0x00031001
-GLFW_LOSE_CONTEXT_ON_RESET  = 0x00031002
+GLFW_NO_ROBUSTNESS = 0
+GLFW_NO_RESET_NOTIFICATION = 0x00031001
+GLFW_LOSE_CONTEXT_ON_RESET = 0x00031002
 
 # ---
-GLFW_OPENGL_ANY_PROFILE     =          0
-GLFW_OPENGL_CORE_PROFILE    = 0x00032001
-GLFW_OPENGL_COMPAT_PROFILE  = 0x00032002
+GLFW_OPENGL_ANY_PROFILE = 0
+GLFW_OPENGL_CORE_PROFILE = 0x00032001
+GLFW_OPENGL_COMPAT_PROFILE = 0x00032002
 
 # ---
-GLFW_CURSOR                 = 0x00033001
-GLFW_STICKY_KEYS            = 0x00033002
-GLFW_STICKY_MOUSE_BUTTONS   = 0x00033003
+GLFW_CURSOR = 0x00033001
+GLFW_STICKY_KEYS = 0x00033002
+GLFW_STICKY_MOUSE_BUTTONS = 0x00033003
 
 # ---
-GLFW_CURSOR_NORMAL          = 0x00034001
-GLFW_CURSOR_HIDDEN          = 0x00034002
-GLFW_CURSOR_DISABLED        = 0x00034003
+GLFW_CURSOR_NORMAL = 0x00034001
+GLFW_CURSOR_HIDDEN = 0x00034002
+GLFW_CURSOR_DISABLED = 0x00034003
 
 # ---
-GLFW_CONNECTED              = 0x00040001
-GLFW_DISCONNECTED           = 0x00040002
+GLFW_CONNECTED = 0x00040001
+GLFW_DISCONNECTED = 0x00040002
 
 
 # --- Structures --------------------------------------------------------------
 class GLFWvidmode(Structure):
-    _fields_ = [ ('width',       c_int),
-                 ('height',      c_int),
-                 ('redBits',     c_int),
-                 ('greenBits',   c_int),
-                 ('blueBits',    c_int),
-                 ('refreshRate', c_int) ]
+    _fields_ = [
+        ("width", c_int),
+        ("height", c_int),
+        ("redBits", c_int),
+        ("greenBits", c_int),
+        ("blueBits", c_int),
+        ("refreshRate", c_int),
+    ]
+
 
 class GLFWgammaramp(Structure):
-    _fields_ = [ ('red',     POINTER(c_ushort)),
-                 ('green',   POINTER(c_ushort)),
-                 ('blue',    POINTER(c_ushort)),
-                 ('size',    c_int) ]
+    _fields_ = [
+        ("red", POINTER(c_ushort)),
+        ("green", POINTER(c_ushort)),
+        ("blue", POINTER(c_ushort)),
+        ("size", c_int),
+    ]
 
-class GLFWwindow(Structure): pass
-class GLFWmonitor(Structure): pass
+
+class GLFWwindow(Structure):
+    pass
+
+
+class GLFWmonitor(Structure):
+    pass
+
 
 # --- Callbacks ---------------------------------------------------------------
-errorfun           = CFUNCTYPE(None, c_int, c_char_p)
-windowposfun       = CFUNCTYPE(None, POINTER(GLFWwindow), c_int, c_int)
-windowsizefun      = CFUNCTYPE(None, POINTER(GLFWwindow), c_int, c_int)
-windowclosefun     = CFUNCTYPE(None, POINTER(GLFWwindow))
-windowrefreshfun   = CFUNCTYPE(None, POINTER(GLFWwindow))
-windowfocusfun     = CFUNCTYPE(None, POINTER(GLFWwindow), c_int)
-windowiconifyfun   = CFUNCTYPE(None, POINTER(GLFWwindow), c_int)
+errorfun = CFUNCTYPE(None, c_int, c_char_p)
+windowposfun = CFUNCTYPE(None, POINTER(GLFWwindow), c_int, c_int)
+windowsizefun = CFUNCTYPE(None, POINTER(GLFWwindow), c_int, c_int)
+windowclosefun = CFUNCTYPE(None, POINTER(GLFWwindow))
+windowrefreshfun = CFUNCTYPE(None, POINTER(GLFWwindow))
+windowfocusfun = CFUNCTYPE(None, POINTER(GLFWwindow), c_int)
+windowiconifyfun = CFUNCTYPE(None, POINTER(GLFWwindow), c_int)
 framebuffersizefun = CFUNCTYPE(None, POINTER(GLFWwindow), c_int, c_int)
-mousebuttonfun     = CFUNCTYPE(None, POINTER(GLFWwindow), c_int, c_int, c_int)
-cursorposfun       = CFUNCTYPE(None, POINTER(GLFWwindow), c_double, c_double)
-cursorenterfun     = CFUNCTYPE(None, POINTER(GLFWwindow), c_int)
-scrollfun          = CFUNCTYPE(None, POINTER(GLFWwindow), c_double, c_double)
-keyfun             = CFUNCTYPE(None, POINTER(GLFWwindow), c_int, c_int, c_int, c_int)
-charfun            = CFUNCTYPE(None, POINTER(GLFWwindow), c_uint)
-monitorfun         = CFUNCTYPE(None, POINTER(GLFWmonitor), c_int)
-dropfun            = CFUNCTYPE(None, POINTER(GLFWmonitor), c_int, POINTER(c_char_p))
+mousebuttonfun = CFUNCTYPE(None, POINTER(GLFWwindow), c_int, c_int, c_int)
+cursorposfun = CFUNCTYPE(None, POINTER(GLFWwindow), c_double, c_double)
+cursorenterfun = CFUNCTYPE(None, POINTER(GLFWwindow), c_int)
+scrollfun = CFUNCTYPE(None, POINTER(GLFWwindow), c_double, c_double)
+keyfun = CFUNCTYPE(None, POINTER(GLFWwindow), c_int, c_int, c_int, c_int)
+charfun = CFUNCTYPE(None, POINTER(GLFWwindow), c_uint)
+monitorfun = CFUNCTYPE(None, POINTER(GLFWmonitor), c_int)
+dropfun = CFUNCTYPE(None, POINTER(GLFWmonitor), c_int, POINTER(c_char_p))
 
 # --- Init --------------------------------------------------------------------
 # glfwInit                        = _glfw.glfwInit
-glfwTerminate                   = _glfw.glfwTerminate
-#glfwGetVersion                 = _glfw.glfwGetVersion
-glfwGetVersionString            = _glfw.glfwGetVersionString
-glfwGetVersionString.restype    = c_char_p
+glfwTerminate = _glfw.glfwTerminate
+# glfwGetVersion                 = _glfw.glfwGetVersion
+glfwGetVersionString = _glfw.glfwGetVersionString
+glfwGetVersionString.restype = c_char_p
 
 
 # --- Error -------------------------------------------------------------------
-#glfwSetErrorCallback            = _glfw.glfwSetErrorCallback
+# glfwSetErrorCallback            = _glfw.glfwSetErrorCallback
 
 # --- Monitor -----------------------------------------------------------------
 # glfwGetMonitors                 = _glfw.glfwGetMonitors
 # glfwGetMonitors.restype         = POINTER(GLFWmonitor)
-glfwGetPrimaryMonitor           = _glfw.glfwGetPrimaryMonitor
+glfwGetPrimaryMonitor = _glfw.glfwGetPrimaryMonitor
 glfwGetPrimaryMonitor.restype = POINTER(GLFWmonitor)
 # glfwGetMonitorPos               = _glfw.glfwGetMonitorPos
 # glfwGetMonitorPhysicalSize      = _glfw.glfwGetMonitorPhysicalSize
-glfwGetMonitorName              = _glfw.glfwGetMonitorName
+glfwGetMonitorName = _glfw.glfwGetMonitorName
 glfwGetMonitorName.restype = c_char_p
 # glfwSetMonitorCallback          = _glfw.glfwSetMonitorCallback
 # glfwGetVideoModes               = _glfw.glfwGetVideoModes
 # glfwGetVideoMode                = _glfw.glfwGetVideoMode
 
 # --- Gama --------------------------------------------------------------------
-glfwSetGamma                   = _glfw.glfwSetGamma
+glfwSetGamma = _glfw.glfwSetGamma
 # glfwGetGammaRamp               = _glfw.glfwGetGammaRamp
 # glfwSetGammaRamp               = _glfw.glfwSetGammaRamp
 
 # --- Window ------------------------------------------------------------------
-glfwDefaultWindowHints         = _glfw.glfwDefaultWindowHints
-glfwWindowHint                 = _glfw.glfwWindowHint
+glfwDefaultWindowHints = _glfw.glfwDefaultWindowHints
+glfwWindowHint = _glfw.glfwWindowHint
 # glfwCreateWindow              = _glfw.glfwCreateWindow
 # glfwDestroyWindow              = _glfw.glfwDestroyWindow
-glfwWindowShouldClose          = _glfw.glfwWindowShouldClose
-glfwSetWindowShouldClose       = _glfw.glfwSetWindowShouldClose
-glfwSetWindowTitle             = _glfw.glfwSetWindowTitle
+glfwWindowShouldClose = _glfw.glfwWindowShouldClose
+glfwSetWindowShouldClose = _glfw.glfwSetWindowShouldClose
+glfwSetWindowTitle = _glfw.glfwSetWindowTitle
 # glfwGetWindowPos              = _glfw.glfwGetWindowPos
-glfwSetWindowPos               = _glfw.glfwSetWindowPos
+glfwSetWindowPos = _glfw.glfwSetWindowPos
 # glfwGetWindowSize             = _glfw.glfwGetWindowSize
-glfwSetWindowSize              = _glfw.glfwSetWindowSize
+glfwSetWindowSize = _glfw.glfwSetWindowSize
 # glfwGetFramebufferSize        = _glfw.glfwGetFramebufferSize
-glfwIconifyWindow              = _glfw.glfwIconifyWindow
-glfwRestoreWindow              = _glfw.glfwRestoreWindow
-glfwShowWindow                 = _glfw.glfwShowWindow
-glfwHideWindow                 = _glfw.glfwHideWindow
-glfwGetWindowMonitor           = _glfw.glfwGetWindowMonitor
-glfwGetWindowAttrib            = _glfw.glfwGetWindowAttrib
-glfwSetWindowUserPointer       = _glfw.glfwSetWindowUserPointer
-glfwGetWindowUserPointer       = _glfw.glfwGetWindowUserPointer
+glfwIconifyWindow = _glfw.glfwIconifyWindow
+glfwRestoreWindow = _glfw.glfwRestoreWindow
+glfwShowWindow = _glfw.glfwShowWindow
+glfwHideWindow = _glfw.glfwHideWindow
+glfwGetWindowMonitor = _glfw.glfwGetWindowMonitor
+glfwGetWindowAttrib = _glfw.glfwGetWindowAttrib
+glfwSetWindowUserPointer = _glfw.glfwSetWindowUserPointer
+glfwGetWindowUserPointer = _glfw.glfwGetWindowUserPointer
 # glfwSetWindowPosCallback       = _glfw.glfwSetWindowPosCallback
 # glfwSetWindowSizeCallback      = _glfw.glfwSetWindowSizeCallback
 # glfwSetWindowCloseCallback     = _glfw.glfwSetWindowCloseCallback
@@ -420,46 +444,45 @@ glfwGetWindowUserPointer       = _glfw.glfwGetWindowUserPointer
 # glfwSetWindowFocusCallback     = _glfw.glfwSetWindowFocusCallback
 # glfwSetWindowIconifyCallback   = _glfw.glfwSetWindowIconifyCallback
 # glfwSetFramebufferSizeCallback = _glfw.glfwSetFramebufferSizeCallback
-glfwPollEvents                 = _glfw.glfwPollEvents
-glfwWaitEvents                 = _glfw.glfwWaitEvents
+glfwPollEvents = _glfw.glfwPollEvents
+glfwWaitEvents = _glfw.glfwWaitEvents
 
 # --- Input -------------------------------------------------------------------
-glfwGetInputMode               = _glfw.glfwGetInputMode
-glfwSetInputMode               = _glfw.glfwSetInputMode
-glfwGetKey                     = _glfw.glfwGetKey
-glfwGetMouseButton             = _glfw.glfwGetMouseButton
+glfwGetInputMode = _glfw.glfwGetInputMode
+glfwSetInputMode = _glfw.glfwSetInputMode
+glfwGetKey = _glfw.glfwGetKey
+glfwGetMouseButton = _glfw.glfwGetMouseButton
 # glfwGetCursorPos               = _glfw.glfwGetCursorPos
-glfwSetCursorPos               = _glfw.glfwSetCursorPos
+glfwSetCursorPos = _glfw.glfwSetCursorPos
 # glfwSetKeyCallback             = _glfw.glfwSetKeyCallback
 # glfwSetCharCallback            = _glfw.glfwSetCharCallback
 # glfwSetMouseButtonCallback     = _glfw.glfwSetMouseButtonCallback
 # glfwSetCursorPosCallback       = _glfw.glfwSetCursorPosCallback
 # glfwSetCursorEnterCallback     = _glfw.glfwSetCursorEnterCallback
 # glfwSetScrollCallback          = _glfw.glfwSetScrollCallback
-glfwJoystickPresent            = _glfw.glfwJoystickPresent
+glfwJoystickPresent = _glfw.glfwJoystickPresent
 # glfwGetJoystickAxes            = _glfw.glfwGetJoystickAxes
 # glfwGetJoystickButtons         = _glfw.glfwGetJoystickButtons
-glfwGetJoystickName            = _glfw.glfwGetJoystickName
+glfwGetJoystickName = _glfw.glfwGetJoystickName
 glfwGetJoystickName.restype = c_char_p
 
 # --- Clipboard ---------------------------------------------------------------
-glfwSetClipboardString         = _glfw.glfwSetClipboardString
-glfwGetClipboardString         = _glfw.glfwGetClipboardString
+glfwSetClipboardString = _glfw.glfwSetClipboardString
+glfwGetClipboardString = _glfw.glfwGetClipboardString
 glfwGetClipboardString.restype = c_char_p
 
 # --- Timer -------------------------------------------------------------------
-glfwGetTime                    = _glfw.glfwGetTime
+glfwGetTime = _glfw.glfwGetTime
 glfwGetTime.restype = c_double
-glfwSetTime                    = _glfw.glfwSetTime
+glfwSetTime = _glfw.glfwSetTime
 
 # --- Context -----------------------------------------------------------------
-glfwMakeContextCurrent         = _glfw.glfwMakeContextCurrent
+glfwMakeContextCurrent = _glfw.glfwMakeContextCurrent
 # glfwGetCurrentContext          = _glfw.glfwGetCurrentContext
-glfwSwapBuffers                = _glfw.glfwSwapBuffers
-glfwSwapInterval               = _glfw.glfwSwapInterval
-glfwExtensionSupported         = _glfw.glfwExtensionSupported
-glfwGetProcAddress             = _glfw.glfwGetProcAddress
-
+glfwSwapBuffers = _glfw.glfwSwapBuffers
+glfwSwapInterval = _glfw.glfwSwapInterval
+glfwExtensionSupported = _glfw.glfwExtensionSupported
+glfwGetProcAddress = _glfw.glfwGetProcAddress
 
 
 # --- Pythonizer --------------------------------------------------------------
@@ -474,6 +497,7 @@ __py_callbacks__ = {}
 
 def glfwInit():
     import os
+
     # glfw changes the directory,so we change it back.
     cwd = os.getcwd()
     # Initialize
@@ -485,38 +509,46 @@ def glfwInit():
         raise Exception("GLFW could not be initialized")
 
 
-def glfwCreateWindow(width=640, height=480, title="GLFW Window", monitor=None, share=None):
+def glfwCreateWindow(
+    width=640, height=480, title="GLFW Window", monitor=None, share=None
+):
     _glfw.glfwCreateWindow.restype = POINTER(GLFWwindow)
-    window = _glfw.glfwCreateWindow(width,height,title.encode('utf-8'),monitor,share)
+    window = _glfw.glfwCreateWindow(
+        width, height, title.encode("utf-8"), monitor, share
+    )
     if window:
         __windows__.append(window)
         index = __windows__.index(window)
         __c_callbacks__[index] = {}
-        __py_callbacks__[index] = { 'errorfun'           : None,
-                                    'monitorfun'         : None,
-                                    'windowposfun'       : None,
-                                    'windowsizefun'      : None,
-                                    'windowclosefun'     : None,
-                                    'windowrefreshfun'   : None,
-                                    'windowfocusfun'     : None,
-                                    'windowiconifyfun'   : None,
-                                    'framebuffersizefun' : None,
-                                    'keyfun'             : None,
-                                    'charfun'            : None,
-                                    'mousebuttonfun'     : None,
-                                    'cursorposfun'       : None,
-                                    'cursorenterfun'     : None,
-                                    'scrollfun'          : None,
-                                    'dropfun'            : None,}
+        __py_callbacks__[index] = {
+            "errorfun": None,
+            "monitorfun": None,
+            "windowposfun": None,
+            "windowsizefun": None,
+            "windowclosefun": None,
+            "windowrefreshfun": None,
+            "windowfocusfun": None,
+            "windowiconifyfun": None,
+            "framebuffersizefun": None,
+            "keyfun": None,
+            "charfun": None,
+            "mousebuttonfun": None,
+            "cursorposfun": None,
+            "cursorenterfun": None,
+            "scrollfun": None,
+            "dropfun": None,
+        }
         return window
     else:
         raise Exception("GLFW window failed to create.")
+
+
 def glfwDestroyWindow(window):
     index = __windows__.index(window)
     try:
         __c_callbacks__[index]
     except KeyError:
-        logger.error('Window already destroyed.')
+        logger.error("Window already destroyed.")
     else:
         _glfw.glfwDestroyWindow(window)
         # We do not delete window from the list (or it would impact windows numbering)
@@ -524,25 +556,30 @@ def glfwDestroyWindow(window):
         del __c_callbacks__[index]
         del __py_callbacks__[index]
 
+
 def glfwGetVersion():
     major, minor, rev = c_int(0), c_int(0), c_int(0)
-    _glfw.glfwGetVersion( byref(major), byref(minor), byref(rev) )
+    _glfw.glfwGetVersion(byref(major), byref(minor), byref(rev))
     return major.value, minor.value, rev.value
+
 
 def glfwGetWindowPos(window):
     xpos, ypos = c_int(0), c_int(0)
     _glfw.glfwGetWindowPos(window, byref(xpos), byref(ypos))
     return xpos.value, ypos.value
 
+
 def glfwGetCursorPos(window):
     xpos, ypos = c_double(0), c_double(0)
     _glfw.glfwGetCursorPos(window, byref(xpos), byref(ypos))
     return xpos.value, ypos.value
 
+
 def glfwGetWindowSize(window):
     width, height = c_int(0), c_int(0)
     _glfw.glfwGetWindowSize(window, byref(width), byref(height))
     return width.value, height.value
+
 
 def glfwGetCurrentContext():
     _glfw.glfwGetCurrentContext.restype = POINTER(GLFWwindow)
@@ -558,59 +595,72 @@ def glfwGetFramebufferSize(window):
 def glfwGetMonitors():
     count = c_int(0)
     _glfw.glfwGetMonitors.restype = POINTER(POINTER(GLFWmonitor))
-    c_monitors = _glfw.glfwGetMonitors( byref(count) )
+    c_monitors = _glfw.glfwGetMonitors(byref(count))
     return [c_monitors[i] for i in range(count.value)]
+
 
 def glfwGetVideoModes(monitor):
     count = c_int(0)
     _glfw.glfwGetVideoModes.restype = POINTER(GLFWvidmode)
-    c_modes = _glfw.glfwGetVideoModes( monitor, byref(count) )
+    c_modes = _glfw.glfwGetVideoModes(monitor, byref(count))
     modes = []
     for i in range(count.value):
-        modes.append( (c_modes[i].width,
-                       c_modes[i].height,
-                       c_modes[i].redBits,
-                       c_modes[i].blueBits,
-                       c_modes[i].greenBits,
-                       c_modes[i].refreshRate ) )
+        modes.append(
+            (
+                c_modes[i].width,
+                c_modes[i].height,
+                c_modes[i].redBits,
+                c_modes[i].blueBits,
+                c_modes[i].greenBits,
+                c_modes[i].refreshRate,
+            )
+        )
     return modes
+
 
 def glfwGetMonitorPos(monitor):
     xpos, ypos = c_int(0), c_int(0)
     _glfw.glfwGetMonitorPos(monitor, byref(xpos), byref(ypos))
     return xpos.value, ypos.value
 
+
 def glfwGetMonitorPhysicalSize(monitor):
     width, height = c_int(0), c_int(0)
     _glfw.glfwGetMonitorPhysicalSize(monitor, byref(width), byref(height))
     return width.value, height.value
 
+
 def glfwGetVideoMode(monitor):
     _glfw.glfwGetVideoMode.restype = POINTER(GLFWvidmode)
     c_mode = _glfw.glfwGetVideoMode(monitor)
-    return (c_mode.contents.width,
-            c_mode.contents.height,
-            c_mode.contents.redBits,
-            c_mode.contents.blueBits,
-            c_mode.contents.greenBits,
-            c_mode.contents.refreshRate )
+    return (
+        c_mode.contents.width,
+        c_mode.contents.height,
+        c_mode.contents.redBits,
+        c_mode.contents.blueBits,
+        c_mode.contents.greenBits,
+        c_mode.contents.refreshRate,
+    )
+
 
 def GetGammaRamp(monitor):
     _glfw.glfwGetGammaRamp.restype = POINTER(GLFWgammaramp)
     c_gamma = _glfw.glfwGetGammaRamp(monitor).contents
-    gamma = {'red':[], 'green':[], 'blue':[]}
+    gamma = {"red": [], "green": [], "blue": []}
     if c_gamma:
         for i in range(c_gamma.size):
-            gamma['red'].append(c_gamma.red[i])
-            gamma['green'].append(c_gamma.green[i])
-            gamma['blue'].append(c_gamma.blue[i])
+            gamma["red"].append(c_gamma.red[i])
+            gamma["green"].append(c_gamma.green[i])
+            gamma["blue"].append(c_gamma.blue[i])
     return gamma
+
 
 def glfwGetJoystickAxes(joy):
     count = c_int(0)
     _glfw.glfwGetJoystickAxes.restype = POINTER(c_float)
     c_axes = _glfw.glfwGetJoystickAxes(joy, byref(count))
     axes = [c_axes[i].value for i in range(count)]
+
 
 def glfwGetJoystickButtons(joy):
     count = c_int(0)
@@ -621,9 +671,10 @@ def glfwGetJoystickButtons(joy):
 
 # --- Callbacks ---------------------------------------------------------------
 
+
 def __callback__(name):
-    callback = 'glfwSet{}Callback'.format(name)
-    fun      = '{}fun'.format(name.lower())
+    callback = "glfwSet{}Callback".format(name)
+    fun = "{}fun".format(name.lower())
     code = """
 def {callback}(window, callback = None):
     index = __windows__.index(window)
@@ -632,21 +683,24 @@ def {callback}(window, callback = None):
     if callback: callback = {fun}(callback)
     __c_callbacks__[index]['{fun}'] = callback
     _glfw.{callback}(window, callback)
-    return old_callback""".format(callback=callback, fun=fun)
+    return old_callback""".format(
+        callback=callback, fun=fun
+    )
     return code
 
-exec(__callback__('Error'))
-exec(__callback__('Monitor'))
-exec(__callback__('WindowPos'))
-exec(__callback__('WindowSize'))
-exec(__callback__('WindowClose'))
-exec(__callback__('WindowRefresh'))
-exec(__callback__('WindowFocus'))
-exec(__callback__('WindowIconify'))
-exec(__callback__('FramebufferSize'))
-exec(__callback__('Key'))
-exec(__callback__('Char'))
-exec(__callback__('MouseButton'))
-exec(__callback__('CursorPos'))
-exec(__callback__('Scroll'))
-exec(__callback__('Drop'))
+
+exec(__callback__("Error"))
+exec(__callback__("Monitor"))
+exec(__callback__("WindowPos"))
+exec(__callback__("WindowSize"))
+exec(__callback__("WindowClose"))
+exec(__callback__("WindowRefresh"))
+exec(__callback__("WindowFocus"))
+exec(__callback__("WindowIconify"))
+exec(__callback__("FramebufferSize"))
+exec(__callback__("Key"))
+exec(__callback__("Char"))
+exec(__callback__("MouseButton"))
+exec(__callback__("CursorPos"))
+exec(__callback__("Scroll"))
+exec(__callback__("Drop"))

--- a/examples/ndsi-client-example.py
+++ b/examples/ndsi-client-example.py
@@ -1,28 +1,34 @@
 import logging, time, signal, sys
+
 logging.basicConfig(
-    format='%(asctime)s [%(levelname)8s | %(name)-14s] %(message)s',
-    datefmt='%H:%M:%S',
-    level=logging.DEBUG
+    format="%(asctime)s [%(levelname)8s | %(name)-14s] %(message)s",
+    datefmt="%H:%M:%S",
+    level=logging.DEBUG,
 )
 logger = logging.getLogger(__name__)
-logging.getLogger('pyre').setLevel(logging.WARNING)
+logging.getLogger("pyre").setLevel(logging.WARNING)
 
 import ndsi
 
 sensors = {}
 
+
 def on_sensor_event(sensor, event):
-    logger.debug('%s [%s] %s %s'%(sensor, event['seq'], event['subject'], event['control_id']))
+    logger.debug(
+        "%s [%s] %s %s" % (sensor, event["seq"], event["subject"], event["control_id"])
+    )
+
 
 def on_network_event(network, event):
-    if event['subject'] == 'attach':
-        sensor = network.sensor(event['sensor_uuid'], callbacks=(on_sensor_event,))
-        logger.debug('Linking sensor %s...'%sensor)
-        sensors[event['sensor_uuid']] = sensor
-    if event['subject'] == 'detach':
-        logger.debug('Unlinking sensor %s...'%event['sensor_uuid'])
-        sensors[event['sensor_uuid']].unlink()
-        del sensors[event['sensor_uuid']]
+    if event["subject"] == "attach":
+        sensor = network.sensor(event["sensor_uuid"], callbacks=(on_sensor_event,))
+        logger.debug("Linking sensor %s..." % sensor)
+        sensors[event["sensor_uuid"]] = sensor
+    if event["subject"] == "detach":
+        logger.debug("Unlinking sensor %s..." % event["sensor_uuid"])
+        sensors[event["sensor_uuid"]].unlink()
+        del sensors[event["sensor_uuid"]]
+
 
 n = ndsi.Network(callbacks=(on_network_event,))
 n.start()
@@ -34,7 +40,7 @@ try:
         for s in sensors.values():
             if s.has_notifications:
                 s.handle_notification()
-        time.sleep(.1)
+        time.sleep(0.1)
 except (KeyboardInterrupt, SystemExit):
     n.stop()
     sys.exit()

--- a/examples/ndsi-gui-client-example.py
+++ b/examples/ndsi-gui-client-example.py
@@ -1,4 +1,4 @@
-'''
+"""
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
  Copyright (C) 2012-2016  Pupil Labs
@@ -9,19 +9,20 @@
 
 pyglui code taken from:
 https://github.com/pupil-labs/pyglui/blob/master/example/example.py
-'''
+"""
 
 import logging, time, signal, sys
+
 logging.basicConfig(
-    format='%(asctime)s [%(levelname)8s | %(name)-14s] %(message)s',
-    datefmt='%H:%M:%S',
-    level=logging.DEBUG
+    format="%(asctime)s [%(levelname)8s | %(name)-14s] %(message)s",
+    datefmt="%H:%M:%S",
+    level=logging.DEBUG,
 )
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
-logging.getLogger('ndsi').setLevel(logging.INFO)
-logging.getLogger('pyre').setLevel(logging.WARNING)
-logging.getLogger('glfw').setLevel(logging.WARNING)
+logging.getLogger("ndsi").setLevel(logging.INFO)
+logging.getLogger("pyre").setLevel(logging.WARNING)
+logging.getLogger("glfw").setLevel(logging.WARNING)
 
 import ndsi
 import pprint, random
@@ -33,7 +34,8 @@ import numpy as np
 
 import time
 from pyglui import __version__ as pyglui_version
-#assert pyglui_version >= '2.0'
+
+# assert pyglui_version >= '2.0'
 
 from pyglui import ui
 from pyglui.cygl.utils import init
@@ -48,11 +50,11 @@ width, height = (1280, 720)
 
 
 def basic_gl_setup():
-    glEnable(GL_POINT_SPRITE )
-    glEnable(GL_VERTEX_PROGRAM_POINT_SIZE) # overwrite pointsize
+    glEnable(GL_POINT_SPRITE)
+    glEnable(GL_VERTEX_PROGRAM_POINT_SIZE)  # overwrite pointsize
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
     glEnable(GL_BLEND)
-    glClearColor(.8,.8,.8,1.)
+    glClearColor(0.8, 0.8, 0.8, 1.0)
     glEnable(GL_LINE_SMOOTH)
     # glEnable(GL_POINT_SMOOTH)
     glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
@@ -61,7 +63,7 @@ def basic_gl_setup():
     glHint(GL_POLYGON_SMOOTH_HINT, GL_NICEST)
 
 
-def adjust_gl_view(w,h,window):
+def adjust_gl_view(w, h, window):
     """
     adjust view onto our scene.
     """
@@ -73,9 +75,8 @@ def adjust_gl_view(w,h,window):
     glLoadIdentity()
 
 
-
 def clear_gl_screen():
-    glClearColor(.9,.9,0.9,1.)
+    glClearColor(0.9, 0.9, 0.9, 1.0)
     glClear(GL_COLOR_BUFFER_BIT)
 
 
@@ -97,10 +98,12 @@ class SensorUIWrapper(object):
         menu_height = 500
         x = random.random()
         y = random.random()
-        x = int(x*(width-menu_width))
-        y = int(y*(height-menu_height))
+        x = int(x * (width - menu_width))
+        y = int(y * (height - menu_height))
 
-        self.menu = ui.Scrolling_Menu(unicode(self.sensor),size=(menu_width,menu_height),pos=(x,y))
+        self.menu = ui.Scrolling_Menu(
+            unicode(self.sensor), size=(menu_width, menu_height), pos=(x, y)
+        )
         self.uvc_menu = ui.Growing_Menu("UVC Controls")
         self.gui.append(self.menu)
         self.update_control_menu()
@@ -116,85 +119,107 @@ class SensorUIWrapper(object):
         if self._initial_refresh:
             self.sensor.refresh_controls()
             self._initial_refresh = False
-        if event['subject'] == 'error':
-            logger.error('Received error %i: %s'%(event['error_no'],event['error_str']))
+        if event["subject"] == "error":
+            logger.error(
+                "Received error %i: %s" % (event["error_no"], event["error_str"])
+            )
         else:
-            logger.info('%s [%s] %s %s'%(sensor, event['seq'], event['subject'], event['control_id']))
-            logger.debug('SET %s'%event['changes'])
-            ctrl_id = event['control_id']
-            if event['changes'].get('value') is None:
-                logger.warning('Control value for %s is None. This is not compliant with v2.12'%event['control_id'])
-            ctrl_dtype = event.get('changes',{}).get('dtype')
-            if (event['control_id'] not in self.control_id_ui_mapping or
-                ctrl_dtype == "strmapping" or ctrl_dtype == "intmapping"):
+            logger.info(
+                "%s [%s] %s %s"
+                % (sensor, event["seq"], event["subject"], event["control_id"])
+            )
+            logger.debug("SET %s" % event["changes"])
+            ctrl_id = event["control_id"]
+            if event["changes"].get("value") is None:
+                logger.warning(
+                    "Control value for %s is None. This is not compliant with v2.12"
+                    % event["control_id"]
+                )
+            ctrl_dtype = event.get("changes", {}).get("dtype")
+            if (
+                event["control_id"] not in self.control_id_ui_mapping
+                or ctrl_dtype == "strmapping"
+                or ctrl_dtype == "intmapping"
+            ):
                 self.update_control_menu()
 
-    def add_controls_to_menu(self,menu,controls):
+    def add_controls_to_menu(self, menu, controls):
         # closure factory
         def make_value_change_fn(ctrl_id):
             def initiate_value_change(val):
-                logger.debug('%s: %s >> %s'%(self.sensor, ctrl_id, val))
+                logger.debug("%s: %s >> %s" % (self.sensor, ctrl_id, val))
                 self.sensor.set_control_value(ctrl_id, val)
+
             return initiate_value_change
 
         for ctrl_id, ctrl_dict in controls:
             try:
-                dtype    = ctrl_dict['dtype']
-                ctrl_ui  = None
+                dtype = ctrl_dict["dtype"]
+                ctrl_ui = None
                 if dtype == "string":
                     ctrl_ui = ui.Text_Input(
-                        'value',
+                        "value",
                         ctrl_dict,
-                        label=ctrl_dict['caption'],
-                        setter=make_value_change_fn(ctrl_id))
+                        label=ctrl_dict["caption"],
+                        setter=make_value_change_fn(ctrl_id),
+                    )
                 elif dtype == "integer" or dtype == "float":
                     convert_fn = int if dtype == "integer" else float
                     ctrl_ui = ui.Slider(
-                        'value',
+                        "value",
                         ctrl_dict,
-                        label=ctrl_dict['caption'],
-                        min =convert_fn(ctrl_dict.get('min', 0)),
-                        max =convert_fn(ctrl_dict.get('max', 100)),
-                        step=convert_fn(ctrl_dict.get('res', 0.)),
-                        setter=make_value_change_fn(ctrl_id))
+                        label=ctrl_dict["caption"],
+                        min=convert_fn(ctrl_dict.get("min", 0)),
+                        max=convert_fn(ctrl_dict.get("max", 100)),
+                        step=convert_fn(ctrl_dict.get("res", 0.0)),
+                        setter=make_value_change_fn(ctrl_id),
+                    )
                 elif dtype == "bool":
                     ctrl_ui = ui.Switch(
-                        'value',
+                        "value",
                         ctrl_dict,
-                        label=ctrl_dict['caption'],
-                        on_val=ctrl_dict.get('max',True),
-                        off_val=ctrl_dict.get('min',False),
-                        setter=make_value_change_fn(ctrl_id))
+                        label=ctrl_dict["caption"],
+                        on_val=ctrl_dict.get("max", True),
+                        off_val=ctrl_dict.get("min", False),
+                        setter=make_value_change_fn(ctrl_id),
+                    )
                 elif dtype == "strmapping" or dtype == "intmapping":
-                    desc_list = ctrl_dict['map']
-                    labels    = [desc['caption'] for desc in desc_list]
-                    selection = [desc['value']   for desc in desc_list]
+                    desc_list = ctrl_dict["map"]
+                    labels = [desc["caption"] for desc in desc_list]
+                    selection = [desc["value"] for desc in desc_list]
+
                     def make_selection_getter(ctrl_dict):
                         def getter():
-                            mapping = ctrl_dict['map']
-                            labels = [entry['caption'] for entry in mapping]
-                            values = [entry['value']   for entry in mapping]
+                            mapping = ctrl_dict["map"]
+                            labels = [entry["caption"] for entry in mapping]
+                            values = [entry["value"] for entry in mapping]
                             return values, labels
+
                         return getter
+
                     ctrl_ui = ui.Selector(
-                        'value',
+                        "value",
                         ctrl_dict,
-                        label=ctrl_dict['caption'],
+                        label=ctrl_dict["caption"],
                         labels=labels,
                         selection=selection,
-                        setter=make_value_change_fn(ctrl_id))
+                        setter=make_value_change_fn(ctrl_id),
+                    )
                 else:
-                    logger.warning('Unknown control type "%s"'%dtype)
+                    logger.warning('Unknown control type "%s"' % dtype)
                 if ctrl_ui:
-                    ctrl_ui.read_only = ctrl_dict.get('readonly',False)
+                    ctrl_ui.read_only = ctrl_dict.get("readonly", False)
                     self.control_id_ui_mapping[ctrl_id] = ctrl_ui
                     menu.append(ctrl_ui)
             except:
-                logger.error('Exception for control:\n{}'.format(pprint.pformat(ctrl_dict)))
+                logger.error(
+                    "Exception for control:\n{}".format(pprint.pformat(ctrl_dict))
+                )
                 import traceback as tb
+
                 tb.logger.debug_exc()
         if len(menu) == 0:
-            menu.append(ui.Info_Text("No %s settings found"%menu.label))
+            menu.append(ui.Info_Text("No %s settings found" % menu.label))
         return menu
 
     def update_control_menu(self):
@@ -207,38 +232,41 @@ class SensorUIWrapper(object):
         for entry in iter(sorted(self.sensor.controls.items())):
             if entry[0].startswith("UVC"):
                 uvc_controls.append(entry)
-            else: other_controls.append(entry)
+            else:
+                other_controls.append(entry)
 
         self.add_controls_to_menu(self.menu, other_controls)
         self.add_controls_to_menu(self.uvc_menu, uvc_controls)
         self.menu.append(self.uvc_menu)
 
-        self.menu.append(ui.Button("Reset to default values",self.sensor.reset_all_control_values))
+        self.menu.append(
+            ui.Button("Reset to default values", self.sensor.reset_all_control_values)
+        )
+
 
 def runNDSIClient():
     global quit
     quit = False
 
     # Callback functions
-    def on_resize(window,w, h):
-        h = max(h,1)
-        w = max(w,1)
-        hdpi_factor = glfwGetFramebufferSize(window)[0]/glfwGetWindowSize(window)[0]
-        w,h = w*hdpi_factor,h*hdpi_factor
-        gui.update_window(w,h)
+    def on_resize(window, w, h):
+        h = max(h, 1)
+        w = max(w, 1)
+        hdpi_factor = glfwGetFramebufferSize(window)[0] / glfwGetWindowSize(window)[0]
+        w, h = w * hdpi_factor, h * hdpi_factor
+        gui.update_window(w, h)
         active_window = glfwGetCurrentContext()
         glfwMakeContextCurrent(window)
         # norm_size = normalize((w,h),glfwGetWindowSize(window))
         # fb_size = denormalize(norm_size,glfwGetFramebufferSize(window))
-        adjust_gl_view(w,h,window)
+        adjust_gl_view(w, h, window)
         glfwMakeContextCurrent(active_window)
 
-
-    def on_iconify(window,iconfied):
+    def on_iconify(window, iconfied):
         pass
 
     def on_key(window, key, scancode, action, mods):
-        gui.update_key(key,scancode,action,mods)
+        gui.update_key(key, scancode, action, mods)
 
         if action == GLFW_PRESS:
             if key == GLFW_KEY_ESCAPE:
@@ -248,36 +276,37 @@ def runNDSIClient():
                     # copy value to system clipboard
                     # ideally copy what is in our text input area
                     test_val = "copied text input"
-                    glfwSetClipboardString(window,test_val)
+                    glfwSetClipboardString(window, test_val)
                     logger.debug("set clipboard to: {}".format(test_val))
                 if key == 86:
                     # copy from system clipboard
                     clipboard = glfwGetClipboardString(window)
                     logger.debug("pasting from clipboard: {}".format(clipboard))
 
-
-    def on_char(window,char):
+    def on_char(window, char):
         gui.update_char(char)
 
-    def on_button(window,button, action, mods):
+    def on_button(window, button, action, mods):
         # logger.debug "button: ", button
         # logger.debug "action: ", action
-        gui.update_button(button,action,mods)
+        gui.update_button(button, action, mods)
         # pos = normalize(pos,glfwGetWindowSize(window))
         # pos = denormalize(pos,(frame.img.shape[1],frame.img.shape[0]) ) # Position in img pixels
 
-    def on_pos(window,x, y):
-        hdpi_factor = float(glfwGetFramebufferSize(window)[0]/glfwGetWindowSize(window)[0])
-        x,y = x*hdpi_factor,y*hdpi_factor
-        gui.update_mouse(x,y)
+    def on_pos(window, x, y):
+        hdpi_factor = float(
+            glfwGetFramebufferSize(window)[0] / glfwGetWindowSize(window)[0]
+        )
+        x, y = x * hdpi_factor, y * hdpi_factor
+        gui.update_mouse(x, y)
 
-    def on_scroll(window,x,y):
-        gui.update_scroll(x,y)
+    def on_scroll(window, x, y):
+        gui.update_scroll(x, y)
 
     def on_close(window):
         global quit
         quit = True
-        logger.info('Process closing from window')
+        logger.info("Process closing from window")
 
     # get glfw started
     glfwInit()
@@ -286,16 +315,16 @@ def runNDSIClient():
     if not window:
         exit()
 
-    glfwSetWindowPos(window,0,0)
+    glfwSetWindowPos(window, 0, 0)
     # Register callbacks for the window
-    glfwSetWindowSizeCallback(window,on_resize)
-    glfwSetWindowCloseCallback(window,on_close)
-    glfwSetWindowIconifyCallback(window,on_iconify)
-    glfwSetKeyCallback(window,on_key)
-    glfwSetCharCallback(window,on_char)
-    glfwSetMouseButtonCallback(window,on_button)
-    glfwSetCursorPosCallback(window,on_pos)
-    glfwSetScrollCallback(window,on_scroll)
+    glfwSetWindowSizeCallback(window, on_resize)
+    glfwSetWindowCloseCallback(window, on_close)
+    glfwSetWindowIconifyCallback(window, on_iconify)
+    glfwSetKeyCallback(window, on_key)
+    glfwSetCharCallback(window, on_char)
+    glfwSetMouseButtonCallback(window, on_button)
+    glfwSetCursorPosCallback(window, on_pos)
+    glfwSetScrollCallback(window, on_scroll)
     # test out new paste function
 
     glfwMakeContextCurrent(window)
@@ -306,6 +335,7 @@ def runNDSIClient():
 
     class Temp(object):
         """Temp class to make objects"""
+
         def __init__(self):
             pass
 
@@ -325,49 +355,51 @@ def runNDSIClient():
     sensors = {}
 
     def on_network_event(network, event):
-        if event['subject'] == 'attach':  # and event['sensor_type'] == 'video':
-            wrapper = SensorUIWrapper(gui, n, event['sensor_uuid'])
-            sensors[event['sensor_uuid']] = wrapper
-            logger.info('Linking sensor {}...'.format(wrapper.sensor))
+        if event["subject"] == "attach":  # and event['sensor_type'] == 'video':
+            wrapper = SensorUIWrapper(gui, n, event["sensor_uuid"])
+            sensors[event["sensor_uuid"]] = wrapper
+            logger.info("Linking sensor {}...".format(wrapper.sensor))
             logger.debug(pprint.pformat(event))
-        if event['subject'] == 'detach':  # and event['sensor_type'] == 'video':
-            logger.info('Unlinking sensor {}...'.format(event['sensor_uuid']))
-            sensors[event['sensor_uuid']].cleanup()
-            del sensors[event['sensor_uuid']]
+        if event["subject"] == "detach":  # and event['sensor_type'] == 'video':
+            logger.info("Unlinking sensor {}...".format(event["sensor_uuid"]))
+            sensors[event["sensor_uuid"]].cleanup()
+            del sensors[event["sensor_uuid"]]
 
     n = ndsi.Network(callbacks=(on_network_event,))
     n.start()
 
     import os
     import psutil
+
     pid = os.getpid()
     ps = psutil.Process(pid)
     ts = time.time()
 
     from pyglui import graph
+
     logger.debug(graph.__version__)
     cpu_g = graph.Line_Graph()
-    cpu_g.pos = (50,100)
+    cpu_g.pos = (50, 100)
     cpu_g.update_fn = ps.cpu_percent
     cpu_g.update_rate = 5
-    cpu_g.label = 'CPU %0.1f'
+    cpu_g.label = "CPU %0.1f"
 
     fps_g = graph.Line_Graph()
-    fps_g.pos = (50,100)
+    fps_g.pos = (50, 100)
     fps_g.update_rate = 5
     fps_g.label = "%0.0f FPS"
-    fps_g.color[:] = .1,.1,.8,.9
+    fps_g.color[:] = 0.1, 0.1, 0.8, 0.9
 
-    on_resize(window,*glfwGetWindowSize(window))
+    on_resize(window, *glfwGetWindowSize(window))
 
     while not quit:
         try:
-            dt,ts = time.time()-ts,time.time()
+            dt, ts = time.time() - ts, time.time()
             clear_gl_screen()
 
             cpu_g.update()
             cpu_g.draw()
-            fps_g.add(1./dt)
+            fps_g.add(1.0 / dt)
             fps_g.draw()
 
             gui.update()
@@ -392,6 +424,7 @@ def runNDSIClient():
     glfwTerminate()
     logger.debug("Process done")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     logging.basicConfig()
     runNDSIClient()

--- a/examples/ndsi-recv-events.py
+++ b/examples/ndsi-recv-events.py
@@ -1,0 +1,62 @@
+import time
+
+# https://github.com/pupil-labs/pyndsi/tree/v1.0
+import ndsi  # Main requirement
+
+EVENT_TYPE = "event"  # Type of sensors that we are interested in
+SENSORS = {}  # Will store connected sensors
+
+
+def main():
+    # Start auto-discovery of Pupil Invisible Companion devices
+    network = ndsi.Network(formats={ndsi.DataFormat.V4}, callbacks=(on_network_event,))
+    network.start()
+
+    try:
+        # Event loop, runs until interrupted
+        while network.running:
+            # Check for recently connected/disconnected devices
+            if network.has_events:
+                network.handle_event()
+
+            # Iterate over all connected devices
+            for event_sensor in SENSORS.values():
+                # Fetch recent sensor configuration changes,
+                # required for pyndsi internals
+                while event_sensor.has_notifications:
+                    event_sensor.handle_notification()
+
+                # Fetch recent event data
+                for event in event_sensor.fetch_data():
+                    # Output: EventValue(timestamp, label)
+                    print(event_sensor, event)
+
+            time.sleep(0.1)
+
+    # Catch interruption and disconnect gracefully
+    except (KeyboardInterrupt, SystemExit):
+        network.stop()
+
+
+def on_network_event(network, event):
+    # Handle event sensor attachment
+    if event["subject"] == "attach" and event["sensor_type"] == EVENT_TYPE:
+        # Create new sensor, start data streaming,
+        # and request current configuration
+        sensor = network.sensor(event["sensor_uuid"])
+        sensor.set_control_value("streaming", True)
+        sensor.refresh_controls()
+
+        # Save sensor s.t. we can fetch data from it in main()
+        SENSORS[event["sensor_uuid"]] = sensor
+        print(f"Added sensor {sensor}...")
+
+    # Handle event sensor detachment
+    if event["subject"] == "detach" and event["sensor_uuid"] in SENSORS:
+        # Known sensor has disconnected, remove from list
+        SENSORS[event["sensor_uuid"]].unlink()
+        del SENSORS[event["sensor_uuid"]]
+        print(f"Removed sensor {event['sensor_uuid']}...")
+
+
+main()  # Execute example

--- a/examples/uvc-ndsi-bridge-host.py
+++ b/examples/uvc-ndsi-bridge-host.py
@@ -10,17 +10,17 @@ import uvc
 import hashlib
 
 logging.basicConfig(
-    format='%(asctime)s [%(levelname)8s | %(name)-14s] %(message)s',
-    datefmt='%H:%M:%S',
-    level=logging.DEBUG
+    format="%(asctime)s [%(levelname)8s | %(name)-14s] %(message)s",
+    datefmt="%H:%M:%S",
+    level=logging.DEBUG,
 )
 logger = logging.getLogger(__name__)
-logging.getLogger('pyre').setLevel(logging.WARNING)
-logging.getLogger('uvc').setLevel(logging.WARNING)
+logging.getLogger("pyre").setLevel(logging.WARNING)
+logging.getLogger("uvc").setLevel(logging.WARNING)
 
-sequence_limit = 2**32-1
+sequence_limit = 2 ** 32 - 1
 
-GROUP = 'pupil-mobile-v3'
+GROUP = "pupil-mobile-v3"
 
 
 def has_data(socket):
@@ -29,6 +29,7 @@ def has_data(socket):
 
 class Bridge(object):
     """docstring for Bridge"""
+
     def __init__(self, uvc_id):
         super(Bridge, self).__init__()
 
@@ -37,24 +38,26 @@ class Bridge(object):
 
         # init capture
         self.cap = uvc.Capture(uvc_id)
-        logger.info('Initialised uvc device {}'.format(self.cap.name))
+        logger.info("Initialised uvc device {}".format(self.cap.name))
 
         # init pyre
-        self.network = Pyre(socket.gethostname()+self.cap.name[-4:])
+        self.network = Pyre(socket.gethostname() + self.cap.name[-4:])
         self.network.join(GROUP)
         self.network.start()
         logger.info('Bridging under "{}"'.format(self.network.name()))
 
         # init sensor sockets
         ctx = zmq.Context()
-        generic_url = 'tcp://*:*'
+        generic_url = "tcp://*:*"
         public_ep = self.network.endpoint()
         self.note, self.note_url = self.bind(ctx, zmq.PUB, generic_url, public_ep)
-        self.data, self.data_url = self.bind(ctx, zmq.PUB, generic_url, public_ep, set_hwm=1)
+        self.data, self.data_url = self.bind(
+            ctx, zmq.PUB, generic_url, public_ep, set_hwm=1
+        )
         self.cmd, self.cmd_url = self.bind(ctx, zmq.PULL, generic_url, public_ep)
 
     def loop(self):
-        logger.info('Entering bridging loop...')
+        logger.info("Entering bridging loop...")
         self.network.shout(GROUP, self.sensor_attach_json().encode())
         try:
             while True:
@@ -66,13 +69,16 @@ class Bridge(object):
             pass
         except Exception:
             import traceback
+
             traceback.print_exc()
         finally:
-            self.network.shout(GROUP, json.dumps({
-                'subject': 'detach',
-                'sensor_uuid': self.network.uuid().hex
-            }).encode())
-            logger.info('Leaving bridging loop...')
+            self.network.shout(
+                GROUP,
+                json.dumps(
+                    {"subject": "detach", "sensor_uuid": self.network.uuid().hex}
+                ).encode(),
+            )
+            logger.info("Leaving bridging loop...")
 
     def publish_frame(self):
         frame = self.cap.get_frame_robust()
@@ -84,13 +90,26 @@ class Bridge(object):
         jpeg_buffer = frame.jpeg_buffer
         m = hashlib.md5(jpeg_buffer)
         lower_end = int(m.hexdigest(), 16) % 0x100000000
-        meta_data = struct.pack('<LLLLdLL', 0x10, frame.width, frame.height, index, now, jpeg_buffer.size, lower_end)
-        self.data.send_multipart([self.network.uuid().hex.encode(), meta_data, jpeg_buffer])
+        meta_data = struct.pack(
+            "<LLLLdLL",
+            0x10,
+            frame.width,
+            frame.height,
+            index,
+            now,
+            jpeg_buffer.size,
+            lower_end,
+        )
+        self.data.send_multipart(
+            [self.network.uuid().hex.encode(), meta_data, jpeg_buffer]
+        )
 
     def poll_network(self):
         for event in self.network.recent_events():
-            if event.type == 'JOIN' and event.group == GROUP:
-                self.network.whisper(event.peer_uuid, self.sensor_attach_json().encode())
+            if event.type == "JOIN" and event.group == GROUP:
+                self.network.whisper(
+                    event.peer_uuid, self.sensor_attach_json().encode()
+                )
 
     def poll_cmd_socket(self):
         while has_data(self.cmd):
@@ -98,16 +117,16 @@ class Bridge(object):
             try:
                 cmd = json.loads(cmd_str.decode())
             except Exception as e:
-                logger.debug('Could not parse received cmd: {}'.format(cmd_str))
+                logger.debug("Could not parse received cmd: {}".format(cmd_str))
             else:
-                logger.debug('Received cmd: {}'.format(cmd))
-                if cmd.get('action') == 'refresh_controls':
+                logger.debug("Received cmd: {}".format(cmd))
+                if cmd.get("action") == "refresh_controls":
                     self.publish_controls()
-                elif cmd.get('action') == 'set_control_value':
-                    val = cmd.get('value', 0)
-                    if cmd.get('control_id') == 'CAM_RATE':
+                elif cmd.get("action") == "set_control_value":
+                    val = cmd.get("value", 0)
+                    if cmd.get("control_id") == "CAM_RATE":
                         self.cap.frame_rate = self.cap.frame_rates[val]
-                    elif cmd.get('control_id') == 'CAM_RES':
+                    elif cmd.get("control_id") == "CAM_RES":
                         self.cap.frame_size = self.cap.frame_sizes[val]
                     self.publish_controls()
 
@@ -118,22 +137,22 @@ class Bridge(object):
         self.network.stop()
 
     def publish_controls(self):
-        self.note.send_multipart([
-            self.network.uuid().hex.encode(),
-            self.frame_size_control_json().encode()])
-        self.note.send_multipart([
-            self.network.uuid().hex.encode(),
-            self.frame_rate_control_json().encode()])
+        self.note.send_multipart(
+            [self.network.uuid().hex.encode(), self.frame_size_control_json().encode()]
+        )
+        self.note.send_multipart(
+            [self.network.uuid().hex.encode(), self.frame_rate_control_json().encode()]
+        )
 
     def sensor_attach_json(self):
         sensor = {
             "subject": "attach",
             "sensor_name": self.cap.name,
             "sensor_uuid": self.network.uuid().hex,
-            "sensor_type": 'video',
+            "sensor_type": "video",
             "notify_endpoint": self.note_url,
             "command_endpoint": self.cmd_url,
-            "data_endpoint": self.data_url
+            "data_endpoint": self.data_url,
         }
         return json.dumps(sensor)
 
@@ -142,50 +161,54 @@ class Bridge(object):
         self.note_seq += 1
         self.note_seq %= sequence_limit
         curr_fs = self.cap.frame_sizes.index(self.cap.frame_size)
-        return json.dumps({
-            "subject": "update",
-            "control_id": "CAM_RES",
-            "seq": index,
-            "changes": {
-                "value": curr_fs,
-                "dtype": 'intmapping',
-                "min": None,
-                "max": None,
-                "res": None,
-                "def": 0,
-                "caption": 'Resolution',
-                "readonly": False,
-                "map": [{
-                    'value': idx,
-                    'caption': '{:d}x{:d}'.format(*fs)
-                } for idx, fs in enumerate(self.cap.frame_sizes)]
+        return json.dumps(
+            {
+                "subject": "update",
+                "control_id": "CAM_RES",
+                "seq": index,
+                "changes": {
+                    "value": curr_fs,
+                    "dtype": "intmapping",
+                    "min": None,
+                    "max": None,
+                    "res": None,
+                    "def": 0,
+                    "caption": "Resolution",
+                    "readonly": False,
+                    "map": [
+                        {"value": idx, "caption": "{:d}x{:d}".format(*fs)}
+                        for idx, fs in enumerate(self.cap.frame_sizes)
+                    ],
+                },
             }
-        })
+        )
 
     def frame_rate_control_json(self):
         index = self.note_seq
         self.note_seq += 1
         self.note_seq %= sequence_limit
         curr_fr = self.cap.frame_rates.index(self.cap.frame_rate)
-        return json.dumps({
-            "subject": "update",
-            "control_id": "CAM_RATE",
-            "seq": index,
-            "changes": {
-                "value": curr_fr,
-                "dtype": 'intmapping',
-                "min": None,
-                "max": None,
-                "res": None,
-                "def": 0,
-                "caption": 'Frame Rate',
-                "readonly": False,
-                "map": [{
-                    'value': idx,
-                    'caption': '{:.1f} Hz'.format(fr)
-                } for idx, fr in enumerate(self.cap.frame_rates)]
+        return json.dumps(
+            {
+                "subject": "update",
+                "control_id": "CAM_RATE",
+                "seq": index,
+                "changes": {
+                    "value": curr_fr,
+                    "dtype": "intmapping",
+                    "min": None,
+                    "max": None,
+                    "res": None,
+                    "def": 0,
+                    "caption": "Frame Rate",
+                    "readonly": False,
+                    "map": [
+                        {"value": idx, "caption": "{:.1f} Hz".format(fr)}
+                        for idx, fr in enumerate(self.cap.frame_rates)
+                    ],
+                },
             }
-        })
+        )
 
     def bind(self, ctx, sock_type, url, public_ep, set_hwm=None):
         sock = ctx.socket(sock_type)
@@ -193,17 +216,17 @@ class Bridge(object):
             sock.set_hwm(set_hwm)
         sock.bind(url)
         ep = sock.last_endpoint.decode()
-        port = ep.split(':')[-1]
-        public_ep.split(':')[-1]
-        public_addr = public_ep.split(':')[:-1]
-        return sock, ':'.join(public_addr+[port])
+        port = ep.split(":")[-1]
+        public_ep.split(":")[-1]
+        public_addr = public_ep.split(":")[:-1]
+        return sock, ":".join(public_addr + [port])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     uuid = None
     dev_list = uvc.Device_List()
     for dev in dev_list:
-        uuid = dev['uid']
+        uuid = dev["uid"]
         if uvc.is_accessible(uuid):
             break
     if uuid:

--- a/ndsi/__init__.py
+++ b/ndsi/__init__.py
@@ -24,7 +24,7 @@ class StreamError(CaptureError):
 from ndsi.formatter import DataFormat
 
 
-__version__ = "1.0"
+__version__ = "1.1.dev0"
 __protocol_version__ = str(DataFormat.latest().version_major)
 
 

--- a/ndsi/__init__.py
+++ b/ndsi/__init__.py
@@ -24,7 +24,7 @@ class StreamError(CaptureError):
 from ndsi.formatter import DataFormat
 
 
-__version__ = "1.1.dev1"
+__version__ = "1.1"
 __protocol_version__ = str(DataFormat.latest().version_major)
 
 

--- a/ndsi/__init__.py
+++ b/ndsi/__init__.py
@@ -24,7 +24,7 @@ class StreamError(CaptureError):
 from ndsi.formatter import DataFormat
 
 
-__version__ = "1.1.dev0"
+__version__ = "1.1.dev1"
 __protocol_version__ = str(DataFormat.latest().version_major)
 
 

--- a/ndsi/formatter.py
+++ b/ndsi/formatter.py
@@ -345,7 +345,7 @@ class _EventDataFormatter_V4(EventDataFormatter):
             - uint32 encoding_le
                 = 0 -> "utf-8"
         3. body:
-            - `encoding_le` encoded string of lenght `body_length_le`
+            - `encoding_le` encoded string of length `body_length_le`
         """
         ts, len_, enc_code = struct.unpack("<qii", data_msg.header)
         ts *= NANO

--- a/ndsi/formatter.py
+++ b/ndsi/formatter.py
@@ -12,11 +12,17 @@ from ndsi.frame import VIDEO_FRAME_FORMAT_H264, VIDEO_FRAME_FORMAT_MJPEG
 
 
 __all__ = [
-    'DataFormat', 'DataFormatter', 'DataMessage',
-    'VideoDataFormatter', 'VideoValue',
-    'GazeDataFormatter', 'GazeValue',
-    'AnnotateDataFormatter', 'AnnotateValue',
-    'IMUDataFormatter', 'IMUValue',
+    "DataFormat",
+    "DataFormatter",
+    "DataMessage",
+    "VideoDataFormatter",
+    "VideoValue",
+    "GazeDataFormatter",
+    "GazeValue",
+    "AnnotateDataFormatter",
+    "AnnotateValue",
+    "IMUDataFormatter",
+    "IMUValue",
 ]
 
 
@@ -37,15 +43,16 @@ class DataFormat(enum.Enum):
     """
     `DataFormat` enum represents the format for serializing and deserializing data between NDSI hosts and clients.
     """
-    V3 = 'v3'
-    V4 = 'v4'
+
+    V3 = "v3"
+    V4 = "v4"
 
     @staticmethod
-    def latest() -> 'DataFormat':
+    def latest() -> "DataFormat":
         return max(DataFormat.supported_formats(), key=lambda f: f.version_major)
 
     @staticmethod
-    def supported_formats() -> typing.Set['DataFormat']:
+    def supported_formats() -> typing.Set["DataFormat"]:
         return set(DataFormat)
 
     @property
@@ -62,13 +69,12 @@ class DataMessage(typing.NamedTuple):
     body: bytes
 
 
-DT = typing.TypeVar('DataValue')
+DT = typing.TypeVar("DataValue")
 
 
 class DataFormatter(typing.Generic[DT], abc.ABC):
-
     @abc.abstractstaticmethod
-    def get_formatter(format: DataFormat) -> 'DataFormatter':
+    def get_formatter(format: DataFormat) -> "DataFormatter":
         pass
 
     @abc.abstractmethod
@@ -87,7 +93,8 @@ class UnsupportedFormatter(DataFormatter[typing.Any]):
     """
     Represents a formatter that is not supported for a specific data format and sensor type combination.
     """
-    def get_formatter(format: DataFormat) -> 'UnsupportedFormatter':
+
+    def get_formatter(format: DataFormat) -> "UnsupportedFormatter":
         return UnsupportedFormatter()
 
     def encode_msg(value: typing.Any) -> DataMessage:
@@ -114,7 +121,9 @@ class VideoDataFormatter(DataFormatter[VideoValue]):
 
     @staticmethod
     @functools.lru_cache(maxsize=1, typed=True)
-    def get_formatter(format: DataFormat) -> typing.Union['VideoDataFormatter', UnsupportedFormatter]:
+    def get_formatter(
+        format: DataFormat,
+    ) -> typing.Union["VideoDataFormatter", UnsupportedFormatter]:
         if format == DataFormat.V3:
             return _VideoDataFormatter_V3()
         if format == DataFormat.V4:
@@ -129,7 +138,7 @@ class _VideoDataFormatter_V3(VideoDataFormatter):
     def decode_msg(self, data_msg: DataMessage) -> VideoValue:
         meta_data = struct.unpack("<LLLLdLL", data_msg.header)
         meta_data = list(meta_data)
-        meta_data[4] *= 1e6 #  Convert timestamp s -> us
+        meta_data[4] *= 1e6  #  Convert timestamp s -> us
         meta_data = tuple(meta_data)
         if meta_data[0] == VIDEO_FRAME_FORMAT_MJPEG:
             return self._frame_factory.create_jpeg_frame(data_msg.body, meta_data)
@@ -138,14 +147,14 @@ class _VideoDataFormatter_V3(VideoDataFormatter):
             self._newest_h264_frame = frame or self._newest_h264_frame
             return self._newest_h264_frame
         else:
-            raise StreamError('Frame was not of format MJPEG or H264')
+            raise StreamError("Frame was not of format MJPEG or H264")
 
 
 class _VideoDataFormatter_V4(VideoDataFormatter):
     def decode_msg(self, data_msg: DataMessage) -> VideoValue:
         meta_data = struct.unpack("<LLLLQLL", data_msg.header)
         meta_data = list(meta_data)
-        meta_data[4] /= 1e3 #  Convert timestamp ns -> us
+        meta_data[4] /= 1e3  #  Convert timestamp ns -> us
         meta_data = tuple(meta_data)
         if meta_data[0] == VIDEO_FRAME_FORMAT_MJPEG:
             return self._frame_factory.create_jpeg_frame(data_msg.body, meta_data)
@@ -154,7 +163,7 @@ class _VideoDataFormatter_V4(VideoDataFormatter):
             self._newest_h264_frame = frame or self._newest_h264_frame
             return self._newest_h264_frame
         else:
-            raise StreamError('Frame was not of format MJPEG or H264')
+            raise StreamError("Frame was not of format MJPEG or H264")
 
 
 ##########
@@ -169,7 +178,9 @@ class AnnotateValue(typing.NamedTuple):
 class AnnotateDataFormatter(DataFormatter[AnnotateValue]):
     @staticmethod
     @functools.lru_cache(maxsize=1, typed=True)
-    def get_formatter(format: DataFormat) -> typing.Union['AnnotateDataFormatter', UnsupportedFormatter]:
+    def get_formatter(
+        format: DataFormat,
+    ) -> typing.Union["AnnotateDataFormatter", UnsupportedFormatter]:
         if format == DataFormat.V3:
             return _AnnotateDataFormatter_V3()
         if format == DataFormat.V4:
@@ -207,7 +218,9 @@ class GazeValue(typing.NamedTuple):
 class GazeDataFormatter(DataFormatter[GazeValue]):
     @staticmethod
     @functools.lru_cache(maxsize=1, typed=True)
-    def get_formatter(format: DataFormat) -> typing.Union['GazeDataFormatter', UnsupportedFormatter]:
+    def get_formatter(
+        format: DataFormat,
+    ) -> typing.Union["GazeDataFormatter", UnsupportedFormatter]:
         if format == DataFormat.V3:
             return UnsupportedFormatter()
         if format == DataFormat.V4:
@@ -220,7 +233,7 @@ class GazeDataFormatter(DataFormatter[GazeValue]):
 
 class _GazeDataFormatter_V4(GazeDataFormatter):
     def decode_msg(self, data_msg: DataMessage) -> GazeValue:
-        ts, = struct.unpack("<Q", data_msg.header)
+        (ts,) = struct.unpack("<Q", data_msg.header)
         ts *= NANO
         x, y = struct.unpack("<ff", data_msg.body)
         return GazeValue(x=x, y=y, timestamp=ts)
@@ -242,7 +255,9 @@ class IMUValue(typing.NamedTuple):
 class IMUDataFormatter(DataFormatter[IMUValue]):
     @staticmethod
     @functools.lru_cache(maxsize=1, typed=True)
-    def get_formatter(format: DataFormat) -> typing.Union['IMUDataFormatter', UnsupportedFormatter]:
+    def get_formatter(
+        format: DataFormat,
+    ) -> typing.Union["IMUDataFormatter", UnsupportedFormatter]:
         if format == DataFormat.V3:
             return _IMUDataFormatter_V3()
         if format == DataFormat.V4:
@@ -267,7 +282,9 @@ class _IMUDataFormatter_V3(IMUDataFormatter):
     )
 
     def decode_msg(self, data_msg: DataMessage) -> IMUValue:
-        content = np.frombuffer(data_msg.body, dtype=self.CONTENT_DTYPE).view(np.recarray)
+        content = np.frombuffer(data_msg.body, dtype=self.CONTENT_DTYPE).view(
+            np.recarray
+        )
         return IMUValue(*content)
 
 
@@ -285,5 +302,56 @@ class _IMUDataFormatter_V4(IMUDataFormatter):
     )
 
     def decode_msg(self, data_msg: DataMessage) -> IMUValue:
-        content = np.frombuffer(data_msg.body, dtype=self.CONTENT_DTYPE).view(np.recarray)
+        content = np.frombuffer(data_msg.body, dtype=self.CONTENT_DTYPE).view(
+            np.recarray
+        )
         return IMUValue(*content)
+
+
+##########
+
+
+class EventValue(typing.NamedTuple):
+    timestamp: float
+    label: str
+
+
+class EventDataFormatter(DataFormatter[EventValue]):
+    @staticmethod
+    @functools.lru_cache(maxsize=1, typed=True)
+    def get_formatter(
+        format: DataFormat,
+    ) -> typing.Union["EventDataFormatter", UnsupportedFormatter]:
+        if format == DataFormat.V3:
+            return UnsupportedFormatter()
+        if format == DataFormat.V4:
+            return _EventDataFormatter_V4()
+        raise ValueError(format)
+
+    def encode_msg(self, value: EventValue) -> DataMessage:
+        raise NotImplementedError()
+
+
+class _EventDataFormatter_V4(EventDataFormatter):
+
+    _encoding_lookup = {
+        0: "utf-8",
+    }
+
+    def decode_msg(self, data_msg: DataMessage) -> EventValue:
+        """
+        1. sensor UUID
+        2. header:
+            - int_64 timestamp_le
+            - uint32 body_length_le
+            - uint32 encoding_le
+                = 0 -> "utf-8"
+        3. body:
+            - `encoding_le` encoded string of lenght `body_length_le`
+        """
+        ts, len_, enc_code = struct.unpack("<qii", data_msg.header)
+        ts *= NANO
+        enc = self._encoding_lookup[enc_code]
+        body = data_msg.body.bytes[:len_]
+        label = body.decode(enc)
+        return EventValue(label=label, timestamp=ts)

--- a/ndsi/formatter.py
+++ b/ndsi/formatter.py
@@ -334,9 +334,7 @@ class EventDataFormatter(DataFormatter[EventValue]):
 
 class _EventDataFormatter_V4(EventDataFormatter):
 
-    _encoding_lookup = {
-        0: "utf-8",
-    }
+    _encoding_lookup = {0: "utf-8"}
 
     def decode_msg(self, data_msg: DataMessage) -> EventValue:
         """

--- a/ndsi/network.py
+++ b/ndsi/network.py
@@ -1,4 +1,4 @@
-'''
+"""
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
  Copyright (C) 2012-2015  Pupil Labs
@@ -6,7 +6,7 @@
  Distributed under the terms of the CC BY-NC-SA License.
  License details are in the file LICENSE, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
-'''
+"""
 
 import abc
 import collections
@@ -16,7 +16,7 @@ import json as serial
 import logging
 import sys
 import time
-import traceback  as tb
+import traceback as tb
 import typing
 
 import zmq
@@ -93,7 +93,9 @@ class NetworkInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def sensor(self, sensor_uuid: str, callbacks: typing.Iterable[NetworkEventCallback]=()) -> Sensor:
+    def sensor(
+        self, sensor_uuid: str, callbacks: typing.Iterable[NetworkEventCallback] = ()
+    ) -> Sensor:
         pass
 
 
@@ -104,14 +106,16 @@ class _NetworkNode(NetworkInterface):
     Creates Pyre node and handles all communication.
     """
 
-    def __init__(self, format: DataFormat, context=None, name=None, headers=(), callbacks=()):
+    def __init__(
+        self, format: DataFormat, context=None, name=None, headers=(), callbacks=()
+    ):
         self._name = name
         self._format = format
         self._headers = headers
         self._pyre_node = None
         self._context = context or zmq.Context()
-        self._sensors = {}
-        self._callbacks = [self._on_event]+list(callbacks)
+        self._sensors_by_host = {}
+        self._callbacks = [self._on_event] + list(callbacks)
         self._warned_once_older_version = False
         self._warned_once_newer_version = False
 
@@ -127,7 +131,10 @@ class _NetworkNode(NetworkInterface):
 
     @property
     def sensors(self) -> typing.Mapping[str, NetworkSensor]:
-        return self._sensors
+        sensors = {}
+        for sensor in self._sensors_by_host.values():
+            sensors.update(sensor)
+        return sensors
 
     @property
     def callbacks(self) -> typing.Iterable[NetworkEventCallback]:
@@ -139,7 +146,7 @@ class _NetworkNode(NetworkInterface):
 
     def start(self):
         # Setup node
-        logger.debug('Starting network...')
+        logger.debug("Starting network...")
         self._pyre_node = Pyre(self._name)
         self._name = self._pyre_node.name()
         for header in self._headers:
@@ -157,17 +164,20 @@ class _NetworkNode(NetworkInterface):
 
     def rejoin(self):
         for sensor_uuid, sensor in list(self.sensors.items()):
-            self._execute_callbacks({
-                'subject': 'detach',
-                'sensor_uuid': sensor_uuid,
-                'sensor_name': sensor['sensor_name'],
-                'host_uuid': sensor['host_uuid'],
-                'host_name': sensor['host_name']})
+            self._execute_callbacks(
+                {
+                    "subject": "detach",
+                    "sensor_uuid": sensor_uuid,
+                    "sensor_name": sensor["sensor_name"],
+                    "host_uuid": sensor["host_uuid"],
+                    "host_name": sensor["host_name"],
+                }
+            )
         self._pyre_node.leave(self._group)
         self._pyre_node.join(self._group)
 
     def stop(self):
-        logger.debug('Stopping network...')
+        logger.debug("Stopping network...")
         self._pyre_node.leave(self._group)
         self._pyre_node.stop()
         self._pyre_node = None
@@ -177,70 +187,91 @@ class _NetworkNode(NetworkInterface):
             return
         event = PyreEvent(self._pyre_node)
         uuid = event.peer_uuid
-        if event.type == 'SHOUT' or event.type == 'WHISPER':
+        if event.type == "SHOUT" or event.type == "WHISPER":
             try:
                 payload = event.msg.pop(0).decode()
                 msg = serial.loads(payload)
-                msg['subject']
-                msg['sensor_uuid']
-                msg['host_uuid'] = event.peer_uuid.hex
-                msg['host_name'] = event.peer_name
+                msg["subject"]
+                msg["sensor_uuid"]
+                msg["host_uuid"] = event.peer_uuid.hex
+                msg["host_name"] = event.peer_name
             except serial.decoder.JSONDecodeError:
                 logger.warning('Malformatted message: "{}"'.format(payload))
             except (ValueError, KeyError):
-                logger.warning('Malformatted message: {}'.format(msg))
+                logger.warning("Malformatted message: {}".format(msg))
             except Exception:
                 logger.debug(tb.format_exc())
             else:
-                if msg['subject'] == 'attach':
-                    if self.sensors.get(msg['sensor_uuid']):
+                if msg["subject"] == "attach":
+                    if self.sensors.get(msg["sensor_uuid"]):
                         # Sensor already attached. Drop event
                         return
-                    sensor_type = SensorType.supported_sensor_type_from_str(msg['sensor_type'])
+                    sensor_type = SensorType.supported_sensor_type_from_str(
+                        msg["sensor_type"]
+                    )
                     if sensor_type is None:
-                        logger.debug('Unsupported sensor type: {}'.format(msg['sensor_type']))
+                        logger.debug(
+                            "Unsupported sensor type: {}".format(msg["sensor_type"])
+                        )
                         return
-                elif msg['subject'] == 'detach':
-                    sensor_entry = self.sensors.get(msg['sensor_uuid'])
+                elif msg["subject"] == "detach":
+                    sensor_entry = self.sensors.get(msg["sensor_uuid"])
                     # Check if sensor has been detached already
-                    if not sensor_entry: return
+                    if not sensor_entry:
+                        return
                     msg.update(sensor_entry)
                 else:
-                    logger.debug('Unknown host message: {}'.format(msg))
+                    logger.debug("Unknown host message: {}".format(msg))
                     return
                 self._execute_callbacks(msg)
-        elif event.type == 'JOIN':
+        elif event.type == "JOIN":
             # possible values for `group_version`
             # - [<unrelated group>]
             # - [<unrelated group>, <unrelated version>]
             # - ['pupil-mobile']
             # - ['pupil-mobile', <version>]
-            group_version = event.group.split('-v')
+            group_version = event.group.split("-v")
             group = group_version[0]
-            version = group_version[1] if len(group_version) > 1 else '0'
-            if group == 'pupil-mobile':
-                if not self._warned_once_older_version and version < __protocol_version__:
-                    logger.warning('Devices with outdated NDSI version found. Please update these devices.')
+            version = group_version[1] if len(group_version) > 1 else "0"
+            if group == "pupil-mobile":
+                if (
+                    not self._warned_once_older_version
+                    and version < __protocol_version__
+                ):
+                    logger.warning(
+                        "Devices with outdated NDSI version found. Please update these devices."
+                    )
                     self._warned_once_older_version = True
-                elif not self._warned_once_newer_version and version > __protocol_version__:
-                    logger.warning('Devices with newer NDSI version found. You should update.')
+                elif (
+                    not self._warned_once_newer_version
+                    and version > __protocol_version__
+                ):
+                    logger.warning(
+                        "Devices with newer NDSI version found. You should update."
+                    )
                     self._warned_once_newer_version = True
 
-        elif event.type == 'EXIT':
+        elif event.type == "EXIT":
             gone_peer = event.peer_uuid.hex
-            for sensor_uuid in list(self.sensors.keys()):
-                host = self.sensors[sensor_uuid]['host_uuid']
-                if host == gone_peer:
-                    self._execute_callbacks({
-                        'subject': 'detach',
-                        'sensor_uuid': sensor_uuid,
-                        'sensor_name': self.sensors[sensor_uuid]['sensor_name'],
-                        'host_uuid': host,
-                        'host_name': self.sensors[sensor_uuid]['host_name']})
+            for host_uuid, sensors in list(self._sensors_by_host.items()):
+                if host_uuid != gone_peer:
+                    continue
+                for sensor_uuid, sensor in list(sensors.items()):
+                    self._execute_callbacks(
+                        {
+                            "subject": "detach",
+                            "sensor_uuid": sensor_uuid,
+                            "sensor_name": sensor["sensor_name"],
+                            "host_uuid": host_uuid,
+                            "host_name": sensor["host_name"],
+                        }
+                    )
         else:
-            logger.debug('Dropping {}'.format(event))
+            logger.debug("Dropping {}".format(event))
 
-    def sensor(self, sensor_uuid: str, callbacks: typing.Iterable[NetworkEventCallback]=()) -> Sensor:
+    def sensor(
+        self, sensor_uuid: str, callbacks: typing.Iterable[NetworkEventCallback] = ()
+    ) -> Sensor:
         try:
             sensor_settings = self.sensors[sensor_uuid].copy()
         except KeyError:
@@ -250,20 +281,22 @@ class _NetworkNode(NetworkInterface):
         sensor_type = SensorType.supported_sensor_type_from_str(sensor_type_str)
 
         if sensor_type is None:
-            raise ValueError('Sensor of type "{}" is not supported.'.format(sensor_type_str))
+            raise ValueError(
+                'Sensor of type "{}" is not supported.'.format(sensor_type_str)
+            )
 
         return Sensor.create_sensor(
             sensor_type=sensor_type,
             format=self._format,
             context=self._context,
             callbacks=callbacks,
-            **sensor_settings
+            **sensor_settings,
         )
 
     # Public
 
     def __str__(self):
-        return '<{} {} [{}]>'.format(__name__, self._name, self._pyre_node.uuid().hex)
+        return "<{} {} [{}]>".format(__name__, self._name, self._pyre_node.uuid().hex)
 
     # Private
 
@@ -276,19 +309,41 @@ class _NetworkNode(NetworkInterface):
             callback(self, event)
 
     def _on_event(self, caller, event):
-        if event['subject'] == 'attach':
+        if event["subject"] == "attach":
             subject_less = event.copy()
-            del subject_less['subject']
-            self.sensors.update({event['sensor_uuid']: subject_less})
-        elif event['subject'] == 'detach':
+            del subject_less["subject"]
+            host_uuid = event["host_uuid"]
+            host_sensor = {event["sensor_uuid"]: subject_less}
             try:
-                del self.sensors[event['sensor_uuid']]
+                self._sensors_by_host[host_uuid].update(host_sensor)
             except KeyError:
-                pass
+                self._sensors_by_host[host_uuid] = host_sensor
+            logger.debug(f'Attached {host_uuid}.{event["sensor_uuid"]}')
+        elif event["subject"] == "detach":
+            for host_uuid, sensors in self._sensors_by_host.items():
+                try:
+                    del sensors[event["sensor_uuid"]]
+                    logger.debug(f'Detached {host_uuid}.{event["sensor_uuid"]}')
+                except KeyError:
+                    pass
+            hosts_to_remove = [
+                host_uuid
+                for host_uuid, sensors in self._sensors_by_host.items()
+                if len(sensors) == 0
+            ]
+            for host_uuid in hosts_to_remove:
+                del self._sensors_by_host[host_uuid]
 
 
 class Network(NetworkInterface):
-    def __init__(self, formats:typing.Set[DataFormat]=None, context=None, name=None, headers=(), callbacks=()):
+    def __init__(
+        self,
+        formats: typing.Set[DataFormat] = None,
+        context=None,
+        name=None,
+        headers=(),
+        callbacks=(),
+    ):
         formats = formats or {DataFormat.latest()}
         self.context = context or zmq.Context()
         self._callbacks = callbacks
@@ -349,7 +404,9 @@ class Network(NetworkInterface):
         for node in self._nodes:
             node.handle_event()
 
-    def sensor(self, sensor_uuid: str, callbacks: typing.Iterable[NetworkEventCallback]=()) -> Sensor:
+    def sensor(
+        self, sensor_uuid: str, callbacks: typing.Iterable[NetworkEventCallback] = ()
+    ) -> Sensor:
         for node in self._nodes:
             if sensor_uuid in node.sensors:
                 return node.sensor(sensor_uuid=sensor_uuid, callbacks=callbacks)

--- a/ndsi/network.py
+++ b/ndsi/network.py
@@ -75,6 +75,12 @@ class NetworkInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def whisper(self, peer, msg_p):
+        """Send message to single peer, specified as a UUID string
+        """
+        pass
+
+    @abc.abstractmethod
     def rejoin(self):
         pass
 
@@ -140,6 +146,14 @@ class _NetworkNode(NetworkInterface):
             self._pyre_node.set_header(*header)
         self._pyre_node.join(self._group)
         self._pyre_node.start()
+
+    def whisper(self, peer, msg_p):
+        if self._format == DataFormat.V3:
+            return  # no-op
+        elif self._format == DataFormat.V4:
+            self._pyre_node.whisper(peer, msg_p)
+        else:
+            raise NotImplementedError()
 
     def rejoin(self):
         for sensor_uuid, sensor in list(self.sensors.items()):
@@ -318,6 +332,10 @@ class Network(NetworkInterface):
     def start(self):
         for node in self._nodes:
             node.start()
+
+    def whisper(self, peer, msg_p):
+        for node in self._nodes:
+            node.whisper(peer=peer, msg_p=msg_p)
 
     def rejoin(self):
         for node in self._nodes:

--- a/ndsi/sensor.py
+++ b/ndsi/sensor.py
@@ -1,4 +1,4 @@
-'''
+"""
 (*)~----------------------------------------------------------------------------------
  Pupil - eye tracking platform
  Copyright (C) 2012-2015  Pupil Labs
@@ -6,7 +6,7 @@
  Distributed under the terms of the CC BY-NC-SA License.
  License details are in the file LICENSE, distributed as part of this software.
 ----------------------------------------------------------------------------------~(*)
-'''
+"""
 
 import abc
 import enum
@@ -16,6 +16,7 @@ import numpy as np
 import zmq
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 from ndsi import StreamError
@@ -27,13 +28,16 @@ from ndsi.formatter import VideoDataFormatter, VideoValue
 from ndsi.formatter import GazeDataFormatter, GazeValue
 from ndsi.formatter import AnnotateDataFormatter, AnnotateValue
 from ndsi.formatter import IMUDataFormatter, IMUValue
+from ndsi.formatter import EventDataFormatter, EventValue
 
 
 NANO = 1e-9
 
+
 class NotDataSubSupportedError(Exception):
     def __init__(self, value=None):
-        self.value = value or 'This sensor does not support data subscription.'
+        self.value = value or "This sensor does not support data subscription."
+
     def __str__(self):
         return repr(self.value)
 
@@ -51,18 +55,21 @@ To add a new sensor, in `sensor.py`:
 
 @enum.unique
 class SensorType(enum.Enum):
-    HARDWARE = 'hardware'
-    VIDEO = 'video'
-    ANNOTATE = 'annotate'
-    GAZE = 'gaze'
-    IMU = 'imu'
+    HARDWARE = "hardware"
+    VIDEO = "video"
+    ANNOTATE = "annotate"
+    GAZE = "gaze"
+    IMU = "imu"
+    EVENT = "event"
 
     @staticmethod
-    def supported_types() -> typing.Set['SensorType']:
+    def supported_types() -> typing.Set["SensorType"]:
         return set(SensorType)
 
     @staticmethod
-    def supported_sensor_type_from_str(sensor_type: str) -> typing.Optional['SensorType']:
+    def supported_sensor_type_from_str(
+        sensor_type: str,
+    ) -> typing.Optional["SensorType"]:
         try:
             sensor_type = SensorType(sensor_type)
         except ValueError:
@@ -76,7 +83,6 @@ class SensorType(enum.Enum):
 
 
 class Sensor:
-
     @staticmethod
     def class_for_type(sensor_type: SensorType):
         try:
@@ -85,27 +91,29 @@ class Sensor:
             raise ValueError("Unknown sensor type: {}".format(sensor_type))
 
     @staticmethod
-    def create_sensor(sensor_type: SensorType, **kwargs) -> 'Sensor':
+    def create_sensor(sensor_type: SensorType, **kwargs) -> "Sensor":
         sensor_class = Sensor.class_for_type(sensor_type=sensor_type)
         # TODO: Passing sensor_type to the class init as str, to preserve API compatibility.
         #       Ideally, the sensor_type passed and stored by Sensor is of type SensorType.
-        kwargs['sensor_type'] = str(sensor_type)
+        kwargs["sensor_type"] = str(sensor_type)
         return sensor_class(**kwargs)
 
-    def __init__(self,
-            format: DataFormat,
-            host_uuid,
-            host_name,
-            sensor_uuid,
-            sensor_name,
-            sensor_type,
-            notify_endpoint,
-            command_endpoint,
-            data_endpoint=None,
-            context=None,
-            callbacks=()):
+    def __init__(
+        self,
+        format: DataFormat,
+        host_uuid,
+        host_name,
+        sensor_uuid,
+        sensor_name,
+        sensor_type,
+        notify_endpoint,
+        command_endpoint,
+        data_endpoint=None,
+        context=None,
+        callbacks=(),
+    ):
         self.format = format
-        self.callbacks = [self.on_notification]+list(callbacks)
+        self.callbacks = [self.on_notification] + list(callbacks)
         self.context = context or zmq.Context()
         self.host_uuid = host_uuid
         self.host_name = host_name
@@ -162,22 +170,32 @@ class Sensor:
             raise NotDataSubSupportedError()
 
     def __str__(self):
-        return '<{} {}@{} [{}]>'.format(__name__, self.name, self.host_name, self.type)
+        return "<{} {}@{} [{}]>".format(__name__, self.name, self.host_name, self.type)
 
     def handle_notification(self):
         raw_notification = self.notify_sub.recv_multipart()
         if len(raw_notification) != 2:
-            logger.debug('Message for sensor {} has not correct amount of frames: {}'.format(self.uuid,raw_notification))
+            logger.debug(
+                "Message for sensor {} has not correct amount of frames: {}".format(
+                    self.uuid, raw_notification
+                )
+            )
             return
         sender_id = raw_notification[0].decode()
         notification_payload = raw_notification[1].decode()
         try:
             if sender_id != self.uuid:
-                raise ValueError('Message was destined for {} but was recieved by {}'.format(sender_id, self.uuid))
+                raise ValueError(
+                    "Message was destined for {} but was recieved by {}".format(
+                        sender_id, self.uuid
+                    )
+                )
             notification = serial.loads(notification_payload)
-            notification['subject']
+            notification["subject"]
         except serial.decoder.JSONDecodeError:
-            logger.debug('JSONDecodeError for payload: `{}`'.format(notification_payload))
+            logger.debug(
+                "JSONDecodeError for payload: `{}`".format(notification_payload)
+            )
         except Exception:
             logger.debug(tb.format_exc())
         else:
@@ -191,31 +209,38 @@ class Sensor:
             callback(self, event)
 
     def on_notification(self, caller, notification):
-        if notification['subject'] == 'update':
+        if notification["subject"] == "update":
+
             class UnsettableDict(dict):
                 def __getitem__(self, key):
                     return self.get(key)
-                def __setitem__(self, key, value):
-                    raise ValueError('Dictionary is read-only. Use Sensor.set_control_value instead.')
 
-            ctrl_id_key = notification['control_id']
+                def __setitem__(self, key, value):
+                    raise ValueError(
+                        "Dictionary is read-only. Use Sensor.set_control_value instead."
+                    )
+
+            ctrl_id_key = notification["control_id"]
             if ctrl_id_key in self.controls:
-                self.controls[ctrl_id_key].update(UnsettableDict(notification['changes']))
-            else: self.controls[ctrl_id_key] = UnsettableDict(notification['changes'])
-        elif notification['subject'] == 'remove':
+                self.controls[ctrl_id_key].update(
+                    UnsettableDict(notification["changes"])
+                )
+            else:
+                self.controls[ctrl_id_key] = UnsettableDict(notification["changes"])
+        elif notification["subject"] == "remove":
             try:
-                del self.controls[notification['control_id']]
+                del self.controls[notification["control_id"]]
             except KeyError:
                 pass
 
-    def get_data(self,copy=True):
+    def get_data(self, copy=True):
         try:
             return self.data_sub.recv_multipart(copy=copy)
         except AttributeError:
             raise NotDataSubSupportedError()
 
     def refresh_controls(self):
-        cmd = serial.dumps({'action': 'refresh_controls'})
+        cmd = serial.dumps({"action": "refresh_controls"})
         self.command_push.send_string(self.uuid, flags=zmq.SNDMORE)
         self.command_push.send_string(cmd)
 
@@ -225,36 +250,46 @@ class Sensor:
 
     def reset_control_value(self, control_id):
         if control_id in self.controls:
-            if 'def' in self.controls[control_id]:
-                value = self.controls[control_id]['def']
+            if "def" in self.controls[control_id]:
+                value = self.controls[control_id]["def"]
                 self.set_control_value(control_id, value)
             else:
-                logger.error(('Could not reset control `{}` because it does not have a default value.').format(control_id))
-        else: logger.error('Could not reset unknown control `{}`'.format(control_id))
+                logger.error(
+                    (
+                        "Could not reset control `{}` because it does not have a default value."
+                    ).format(control_id)
+                )
+        else:
+            logger.error("Could not reset unknown control `{}`".format(control_id))
 
     def set_control_value(self, control_id, value):
         try:
-            dtype = self.controls[control_id]['dtype']
-            if dtype == 'bool': value = bool(value)
-            elif dtype == 'string': value = str(value)
-            elif dtype == 'integer': value = int(value)
-            elif dtype == 'float': value = float(value)
-            elif dtype == 'intmapping': value = int(value)
-            elif dtype == 'strmapping': value = str(value)
+            dtype = self.controls[control_id]["dtype"]
+            if dtype == "bool":
+                value = bool(value)
+            elif dtype == "string":
+                value = str(value)
+            elif dtype == "integer":
+                value = int(value)
+            elif dtype == "float":
+                value = float(value)
+            elif dtype == "intmapping":
+                value = int(value)
+            elif dtype == "strmapping":
+                value = str(value)
         except KeyError:
             pass
-        cmd = serial.dumps({
-            "action": "set_control_value",
-            "control_id": control_id,
-            "value": value})
+        cmd = serial.dumps(
+            {"action": "set_control_value", "control_id": control_id, "value": value}
+        )
         self.command_push.send_string(self.uuid, flags=zmq.SNDMORE)
         self.command_push.send_string(cmd)
 
 
-SensorFetchDataValue = typing.TypeVar('FetchDataValue')
+SensorFetchDataValue = typing.TypeVar("FetchDataValue")
+
 
 class SensorFetchDataMixin(typing.Generic[SensorFetchDataValue], abc.ABC):
-
     @property
     @abc.abstractmethod
     def formatter(self) -> DataFormatter[SensorFetchDataValue]:
@@ -296,9 +331,9 @@ class VideoSensor(SensorFetchDataMixin[VideoValue], Sensor):
             if newest_frame is not None:
                 return newest_frame
             else:
-                raise StreamError('Operation timed out.')
+                raise StreamError("Operation timed out.")
         else:
-            raise StreamError('Operation timed out.')
+            raise StreamError("Operation timed out.")
 
 
 class AnnotateSensor(SensorFetchDataMixin[AnnotateValue], Sensor):
@@ -328,10 +363,17 @@ class IMUSensor(SensorFetchDataMixin[IMUValue], Sensor):
         return IMUDataFormatter.get_formatter(format=self.format)
 
 
+class EventSensor(SensorFetchDataMixin[EventValue], Sensor):
+    @property
+    def formatter(self) -> EventDataFormatter:
+        return EventDataFormatter.get_formatter(format=self.format)
+
+
 _SENSOR_TYPE_CLASS_MAP = {
     SensorType.HARDWARE: Sensor,
     SensorType.VIDEO: VideoSensor,
     SensorType.ANNOTATE: AnnotateSensor,
     SensorType.GAZE: GazeSensor,
     SensorType.IMU: IMUSensor,
+    SensorType.EVENT: EventSensor,
 }

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -8,20 +8,18 @@ from ndsi.formatter import IMUDataFormatter
 from ndsi.formatter import VideoDataFormatter
 
 
-DataFixture = collections.namedtuple('DataFixture', ['value', 'data_msg'])
+DataFixture = collections.namedtuple("DataFixture", ["value", "data_msg"])
 
 
 @pytest.fixture
 def gaze_v4_fixture() -> DataFixture:
     value = GazeValue(
-        x=564.1744384765625,
-        y=542.271240234375,
-        timestamp=1564499230.2196853,
+        x=564.1744384765625, y=542.271240234375, timestamp=1564499230.2196853
     )
     data_msg = DataMessage(
-        sensor_id='6678360f-9850-468e-8b44-47b7c43712dc',
-        header=b'\x08\xcd\x9d\xc4\xc27\xb6\x15',
-        body=b'*\x0b\rD\\\x91\x07D',
+        sensor_id="6678360f-9850-468e-8b44-47b7c43712dc",
+        header=b"\x08\xcd\x9d\xc4\xc27\xb6\x15",
+        body=b"*\x0b\rD\\\x91\x07D",
     )
     return DataFixture(value=value, data_msg=data_msg)
 
@@ -55,7 +53,9 @@ def test_gaze_formatter_v4(gaze_v4_fixture: DataFixture):
 def test_annotate_formatter():
     for format in DataFormat.supported_formats():
         annotate_formatter = AnnotateDataFormatter.get_formatter(format=format)
-        assert isinstance(annotate_formatter, (AnnotateDataFormatter, UnsupportedFormatter))
+        assert isinstance(
+            annotate_formatter, (AnnotateDataFormatter, UnsupportedFormatter)
+        )
 
 
 def test_imu_formatter():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,12 +11,14 @@ def test_supported_types():
 def test_sensor_types_factory():
     # valid sensor types
     for sensor_type_expected in SensorType.supported_types():
-        sensor_type_actual = SensorType.supported_sensor_type_from_str(str(sensor_type_expected))
+        sensor_type_actual = SensorType.supported_sensor_type_from_str(
+            str(sensor_type_expected)
+        )
         assert sensor_type_actual is not None
         assert isinstance(sensor_type_actual, SensorType)
         assert sensor_type_actual is sensor_type_expected
     # invalid sensor types
-    sensor_type = SensorType.supported_sensor_type_from_str('foo')
+    sensor_type = SensorType.supported_sensor_type_from_str("foo")
     assert sensor_type is None
 
 


### PR DESCRIPTION
This PR adds support for receiving published "events" (alternatively triggers or annotations).

## _event_ sensor

- NDSI sensor type `event`
- Supports data subscription
- _Header_:
  - `timestamp`: `int64`, little endian, nanoseconds since unix epoch
  - `body length`: `uint32`, little endian, number of bytes in _body_
  - `encoding`: `uint32`, little endian, integer value representing encoding used to encode _body_
    - Currently only `0` (`utf-8`) is supported.
- _Body_:
  - `body length` bytes representing a string encoded with `encoding`

## Sending "events" to the host

Hosts with an `event` sensor support receiving external events from clients. This is implemented via [ZRE whispers](https://rfc.zeromq.org/spec:36/ZRE/#the-whisper-command) whose content is a [json encoded object](https://www.json.org/json-en.html) with the following fields:
- `"name"`: _required_, value is the event's title/label/name as a json string 
- `"timestamp"`: _optional_, value is the external event's timestamp in nanoseconds since Unix epoch as a json number. If this field is not provided, the host will use the reception time as timestamp.

Valid events received by the host will be published to the `event` sensor. As a result, clients can receive an echo of their own events if they subscribe to the `event` sensor.

This can be used by the client to calculate the round trip time and time offset to the host. The client procedure looks like this:
```markdown
1. Connect and subscribe to `event` sensor
2. Save current client timestamp `t0`
3. Send `{"name": "<<time>>"}` event to host
4. On receiving the echo, save the current client timestamp `t1`
5. The echo includes the host's reception time `t_host`
6. Round trip time: `t1 - t0`
7. Client-host time difference: `(t0 + t1) / 2 - t_host`
```