### PR TITLE
Fix H264 to BGR conversion

### DIFF
--- a/ndsi/__init__.py
+++ b/ndsi/__init__.py
@@ -24,7 +24,7 @@ class StreamError(CaptureError):
 from ndsi.formatter import DataFormat
 
 
-__version__ = "1.2"
+__version__ = "1.3"
 __protocol_version__ = str(DataFormat.latest().version_major)
 
 

--- a/ndsi/frame.pyx
+++ b/ndsi/frame.pyx
@@ -400,7 +400,7 @@ cdef class H264Frame:
         cdef int result
         self._bgr_buffer = np.empty(self.width*self.height*channels, dtype=np.uint8)
         result = turbojpeg.tjDecodeYUV(
-            self.tj_context, &self._yuv_buffer[0], 4, turbojpeg.TJSAMP_420,
+            self.tj_context, &self._yuv_buffer[0], 4, turbojpeg.TJSAMP_422,
             &self._bgr_buffer[0], self.width, 0,
             self.height, turbojpeg.TJPF_BGR, 0)
         if result == -1:


### PR DESCRIPTION
The H264 decoder was setup to use [`YUV422`](https://github.com/pupil-labs/pyndsi/blob/master/ndsi/frame.pyx#L71) but the yuv decoder was set to `YUV420`.