### PR TITLE
Allow multiple values to be extracted from a single message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.mypy_cache
 
 # Translations
 *.mo

--- a/ndsi/__init__.py
+++ b/ndsi/__init__.py
@@ -24,7 +24,7 @@ class StreamError(CaptureError):
 from ndsi.formatter import DataFormat
 
 
-__version__ = "1.3"
+__version__ = "1.4"
 __protocol_version__ = str(DataFormat.latest().version_major)
 
 

--- a/ndsi/formatter.py
+++ b/ndsi/formatter.py
@@ -309,7 +309,7 @@ class _IMUDataFormatter_V4(IMUDataFormatter):
             np.recarray
         )
         for imu_frame in content:
-            yield IMUValue(*content)
+            yield IMUValue(*imu_frame)
 
 
 ##########

--- a/ndsi/formatter.py
+++ b/ndsi/formatter.py
@@ -143,11 +143,11 @@ class _VideoDataFormatter_V3(VideoDataFormatter):
         meta_data_mutable[4] *= 1e6  #  Convert timestamp s -> us
         meta_data = tuple(meta_data_mutable)
         if meta_data[0] == VIDEO_FRAME_FORMAT_MJPEG:
-            return self._frame_factory.create_jpeg_frame(data_msg.body, meta_data)
+            yield self._frame_factory.create_jpeg_frame(data_msg.body, meta_data)
         elif meta_data[0] == VIDEO_FRAME_FORMAT_H264:
             frame = self._frame_factory.create_h264_frame(data_msg.body, meta_data)
             self._newest_h264_frame = frame or self._newest_h264_frame
-            return self._newest_h264_frame
+            yield self._newest_h264_frame
         else:
             raise StreamError("Frame was not of format MJPEG or H264")
 
@@ -159,11 +159,11 @@ class _VideoDataFormatter_V4(VideoDataFormatter):
         meta_data_mutable[4] /= 1e3  #  Convert timestamp ns -> us
         meta_data = tuple(meta_data_mutable)
         if meta_data[0] == VIDEO_FRAME_FORMAT_MJPEG:
-            return self._frame_factory.create_jpeg_frame(data_msg.body, meta_data)
+            yield self._frame_factory.create_jpeg_frame(data_msg.body, meta_data)
         elif meta_data[0] == VIDEO_FRAME_FORMAT_H264:
             frame = self._frame_factory.create_h264_frame(data_msg.body, meta_data)
             self._newest_h264_frame = frame or self._newest_h264_frame
-            return self._newest_h264_frame
+            yield self._newest_h264_frame
         else:
             raise StreamError("Frame was not of format MJPEG or H264")
 

--- a/ndsi/sensor.py
+++ b/ndsi/sensor.py
@@ -305,8 +305,7 @@ class SensorFetchDataMixin(typing.Generic[SensorFetchDataValue], abc.ABC):
         while self.has_data:
             data_msg = self.get_data(copy=False)
             data_msg = DataMessage(*data_msg)
-            value = self.formatter.decode_msg(data_msg=data_msg)
-            yield value
+            yield from self.formatter.decode_msg(data_msg=data_msg)
 
 
 class VideoSensor(SensorFetchDataMixin[VideoValue], Sensor):

--- a/ndsi/sensor.py
+++ b/ndsi/sensor.py
@@ -75,7 +75,7 @@ class SensorType(enum.Enum):
             sensor_type = SensorType(sensor_type_name)
         except ValueError:
             return None
-        if sensor_type_name not in SensorType.supported_types():
+        if sensor_type not in SensorType.supported_types():
             return None
         return sensor_type
 

--- a/ndsi/sensor.py
+++ b/ndsi/sensor.py
@@ -69,13 +69,13 @@ class SensorType(enum.Enum):
 
     @staticmethod
     def supported_sensor_type_from_str(
-        sensor_type: str,
+        sensor_type_name: str,
     ) -> typing.Optional["SensorType"]:
         try:
-            sensor_type = SensorType(sensor_type)
+            sensor_type = SensorType(sensor_type_name)
         except ValueError:
             return None
-        if sensor_type not in SensorType.supported_types():
+        if sensor_type_name not in SensorType.supported_types():
             return None
         return sensor_type
 
@@ -124,7 +124,7 @@ class Sensor:
         self.notify_endpoint = notify_endpoint
         self.command_endpoint = command_endpoint
         self.data_endpoint = data_endpoint
-        self.controls = {}
+        self.controls: typing.Dict[str, typing.Any] = {}
 
         self.notify_sub = context.socket(zmq.SUB)
         self.notify_sub.connect(self.notify_endpoint)
@@ -287,7 +287,7 @@ class Sensor:
         self.command_push.send_string(cmd)
 
 
-SensorFetchDataValue = typing.TypeVar("FetchDataValue")
+SensorFetchDataValue = typing.TypeVar("SensorFetchDataValue")
 
 
 class SensorFetchDataMixin(typing.Generic[SensorFetchDataValue], abc.ABC):


### PR DESCRIPTION
The IMU sensor sends multiple imu frames per message. This PR fixes #48 by changing `DataFormatter.decode_msg()` to return an iterator. This change does not affect the `SensorFetchDataMixin.fetch_data()` api.