### PR TITLE
Update TurboJPEG install instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ sudo apt install -y libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev
 
 ##### TurboJPEG
 ```sh
+sudo apt install nasm
 wget -O libjpeg-turbo.tar.gz https://sourceforge.net/projects/libjpeg-turbo/files/1.5.1/libjpeg-turbo-1.5.1.tar.gz/download
 tar xvzf libjpeg-turbo.tar.gz
 cd libjpeg-turbo-1.5.1
@@ -40,6 +41,7 @@ sudo apt install -y libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev
 
 ##### TurboJPEG
 ```sh
+sudo apt install nasm
 wget -O libjpeg-turbo.tar.gz https://sourceforge.net/projects/libjpeg-turbo/files/1.5.1/libjpeg-turbo-1.5.1.tar.gz/download
 tar xvzf libjpeg-turbo.tar.gz
 cd libjpeg-turbo-1.5.1


### PR DESCRIPTION
This fixes the TurboJPEG configure step on Ubuntu by
adding a step to install NASM.

The ./configure --enable-static=no --prefix=/usr/local
 command was failing with:
"configure: error: no nasm (Netwide Assembler)

Tested on Ubuntu 18.04.