### PR TITLE
Added safeguard for ffmpeg version >= 6

### DIFF
--- a/src/ndsi/h264/h264_decoder.cpp
+++ b/src/ndsi/h264/h264_decoder.cpp
@@ -61,9 +61,11 @@ H264Decoder::H264Decoder(const color_format_t &_color_format)
 		if (LIKELY(codec_context)) {
 			codec_context->pix_fmt = color_format;
 			codec_context->flags2 |= AV_CODEC_FLAG2_CHUNKS;
+#if LIBAVCODEC_VERSION_MAJOR < 60
 			if (codec->capabilities & AV_CODEC_CAP_TRUNCATED) {
 				codec_context->flags |= AV_CODEC_FLAG_TRUNCATED;
 			}
+#endif
 			int result = avcodec_open2(codec_context, codec, NULL);
 			if (LIKELY(!result)) {
 				src = av_frame_alloc();


### PR DESCRIPTION
This proposes a fix for issue #87, based on the solution proposed in obsproject/obs-studio#8376 . From ffmpeg 6 onwards, the `AV_CODEC_CAP_TRUNCATED` has been removed. The current implementation should not change the behavior for FFmpeg version < 6.